### PR TITLE
docs: update README for new node structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,17 @@
 # wildcard_tagnodes
 
-ComfyUI 向けのワイルドカードタグ生成ノード集です。服装やポーズに加え、髪型や体型、アクセサリー、ライティング、カメラアングル、アートスタイルなど多様なタグをランダムに生成します。
+ComfyUI 向けのワイルドカードタグ生成ノード集です。服装や外見（髪・体型）、アクセサリー、背景、ポーズ・表情、カメラ×ライティング、アートスタイルなど多様なタグをランダムに生成します。
 
 ## 利用可能なノード
 - 服装タグ生成 (ClothingTagNode)
-- ポーズタグ生成 (PoseTagNode)
-- 表情タグ生成 (ExpressionTagNode)
+- 外見タグ生成 (AppearanceTagNode) — 髪と体型をまとめて生成
+- アクセサリータグ生成 (AccessoryTagNode)
 - 背景タグ生成 (BackgroundTagNode)
 - ポーズ・表情タグ生成 (PoseEmotionTagNode)
-- 髪型タグ生成 (HairTagNode)
-- 体型タグ生成 (BodyTypeTagNode)
-- アクセサリータグ生成 (AccessoryTagNode)
-- ライティングタグ生成 (LightingTagNode)
-- カメラアングルタグ生成 (CameraAngleTagNode)
+- カメラ×ライティング統合タグ生成 (CameraLightingTagNode)
 - アートスタイルタグ生成 (ArtStyleTagNode)
 
-各ノードは `seed` を受け取り、確率設定や最大文字数、出力の小文字化など共通のオプションを備えています。
+各ノードは `seed` を受け取り、確率設定や最大文字数、出力の小文字化など共通のオプションを備えています。統合ノードにより、髪と体型、ポーズと表情、カメラとライティングといった関連要素を一度に生成できるようになりました。
 
 ## インストール
 このリポジトリを `ComfyUI/custom_nodes` に配置するだけで利用可能です。


### PR DESCRIPTION
## Summary
- refresh README to reflect merged node structure
- list current tag generation nodes and mention integrated variants

## Testing
- `python -m compileall -q .`
- `python - <<'PY'
import sys
sys.path.append('..')
from wildcard_tagnodes.clothing_tag import ClothingTagNode
from wildcard_tagnodes.background_tag import BackgroundTagNode
from wildcard_tagnodes.pose_emotion_tag import PoseEmotionTagNode
from wildcard_tagnodes.accessory_tag import AccessoryTagNode
from wildcard_tagnodes.art_style_tag import ArtStyleTagNode
from wildcard_tagnodes.appearance_tag import AppearanceTagNode
from wildcard_tagnodes.camera_lighting_tag import CameraLightingTagNode
nodes = [ClothingTagNode(), BackgroundTagNode(), PoseEmotionTagNode(), AccessoryTagNode(), ArtStyleTagNode(), AppearanceTagNode(), CameraLightingTagNode()]
seed = 123
for node in nodes:
    out = node.generate(seed)
    print(node.__class__.__name__, '->', out[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a23160333083268d8fbac8d50fe6eb