### PR TITLE
Refactor pose emotion vocab and theme integration

### DIFF
--- a/vocab/pose_emotion_vocab.py
+++ b/vocab/pose_emotion_vocab.py
@@ -13,9 +13,7 @@ vocab/improved_pose_emotion_vocab.py (Full Script / Standalone)
 """
 
 from __future__ import annotations
-from pathlib import Path
 from typing import List, Dict, Set
-import re
 
 # ========================================
 # ユーティリティ関数
@@ -156,36 +154,95 @@ EXPRESSION_MODES: Dict[str, Dict[str, List[str]]] = {
     "erotic": {"mood": _merge_unique(MOOD_ALLURE, MOOD_EROTIC)},
 }
 
-EMOTION_THEME_PACKS: Dict[str, Dict[str, List[str]]] = {
+EMOTION_THEME_PACKS: Dict[str, Dict[str, object]] = {
     "Jubilant_Joy": {
-        "pose_boost": ["jumping", "dancing", "twirling", "arms outstretched", "leaping"],
-        "expr_boost": ["ecstatic", "beaming", "laughing", "joyful", "sparkling eyes"],
-        "camera_boost": ["wide angle", "full shot", "dynamic pose"],
+        "tags": {
+            "pose": ["jumping", "dancing", "twirling", "arms outstretched", "leaping"],
+            "expression": ["ecstatic", "beaming", "laughing", "joyful", "sparkling eyes"],
+            "camera": ["wide angle", "full shot", "dynamic pose"],
+        },
+        "focus": {
+            "pose": ["pose_dynamic", "pose_standing", "pose_sitting"],
+            "expression": ["joy"],
+        },
+        "conflicts": {
+            "pose_categories": ["pose_lying"],
+            "mood_labels": ["sadness", "anger"],
+        },
     },
     "Quiet_Sorrow": {
-        "pose_boost": ["hugging knees", "sitting on the floor", "slumped shoulders", "head down", "covering face"],
-        "expr_boost": ["melancholy", "crying", "tearful", "sorrowful", "furrowed brows"],
-        "camera_boost": ["close-up", "from above", "rainy"],
+        "tags": {
+            "pose": ["hugging knees", "sitting on the floor", "slumped shoulders", "head down", "covering face"],
+            "expression": ["melancholy", "crying", "tearful", "sorrowful", "furrowed brows"],
+            "camera": ["close-up", "from above", "rainy"],
+        },
+        "focus": {
+            "pose": ["pose_sitting", "pose_lying", "pose_standing"],
+            "expression": ["sadness"],
+        },
+        "conflicts": {
+            "pose_categories": ["pose_dynamic"],
+            "mood_labels": ["joy", "anger", "erotic"],
+            "camera_tags": ["dutch angle"],
+        },
     },
     "Burning_Anger": {
-        "pose_boost": ["power stance", "fist clenched", "fighting stance", "pointing"],
-        "expr_boost": ["furious", "glaring", "scowling", "shouting", "enraged"],
-        "camera_boost": ["dutch angle", "low angle", "dramatic lighting"],
+        "tags": {
+            "pose": ["power stance", "fist clenched", "fighting stance", "pointing"],
+            "expression": ["furious", "glaring", "scowling", "shouting", "enraged"],
+            "camera": ["dutch angle", "low angle", "dramatic lighting"],
+        },
+        "focus": {
+            "pose": ["pose_dynamic", "pose_standing"],
+            "expression": ["anger"],
+        },
+        "conflicts": {
+            "pose_categories": ["pose_lying"],
+            "mood_labels": ["joy", "sadness"],
+        },
     },
     "Seductive_Allure": {
-        "pose_boost": ["arched back", "looking over shoulder", "touching hair", "one leg forward"],
-        "expr_boost": ["seductive", "flirtatious", "biting lip", "winking", "smirk"],
-        "camera_boost": ["medium close-up", "bust shot", "soft lighting"],
+        "tags": {
+            "pose": ["arched back", "looking over shoulder", "touching hair", "one leg forward"],
+            "expression": ["seductive", "flirtatious", "biting lip", "winking", "smirk"],
+            "camera": ["medium close-up", "bust shot", "soft lighting"],
+        },
+        "focus": {
+            "pose": ["pose_standing", "pose_sitting", "pose_dynamic"],
+            "expression": ["allure"],
+        },
+        "conflicts": {
+            "mood_labels": ["anger", "sadness"],
+        },
     },
     "Deep_Ponder": {
-        "pose_boost": ["sitting cross-legged", "cupping chin", "leaning forward", "hand on cheek"],
-        "expr_boost": ["pensive", "thoughtful", "serious", "neutral expression", "knitted brows"],
-        "camera_boost": ["face shot", "point of view shot", "window light"],
+        "tags": {
+            "pose": ["sitting cross-legged", "cupping chin", "leaning forward", "hand on cheek"],
+            "expression": ["pensive", "thoughtful", "serious", "neutral expression", "knitted brows"],
+            "camera": ["face shot", "point of view shot", "window light"],
+        },
+        "focus": {
+            "pose": ["pose_sitting", "pose_standing"],
+            "expression": ["daily"],
+        },
+        "conflicts": {
+            "pose_categories": ["pose_dynamic"],
+            "mood_labels": ["anger", "erotic"],
+        },
     },
     "Passionate_Embrace": {
-        "pose_boost": ["arched back", "lying on back", "hands behind head", "legs wrapped around", "embracing"],
-        "expr_boost": ["lustful", "ecstasy", "biting lip", "breathless", "half-closed eyes", "passionate"],
-        "camera_boost": ["close-up", "tight crop", "dramatic lighting", "shadows"],
+        "tags": {
+            "pose": ["arched back", "lying on back", "hands behind head", "legs wrapped around", "embracing"],
+            "expression": ["lustful", "ecstasy", "biting lip", "breathless", "half-closed eyes", "passionate"],
+            "camera": ["close-up", "tight crop", "dramatic lighting", "shadows"],
+        },
+        "focus": {
+            "pose": ["pose_lying", "pose_sitting", "pose_dynamic"],
+            "expression": ["erotic", "allure"],
+        },
+        "conflicts": {
+            "mood_labels": ["sadness", "anger"],
+        },
     },
 }
 
@@ -218,135 +275,57 @@ NSFW_SUGGESTIVE_MICRO = ["barely parted teeth", "quivering lips"]
 # --- 露骨な語彙（スクリプト内直書き） ---
 # [更新] ユーザー提供の語彙を直接リストとして定義
 EXPLICIT_SEX_POSES: List[str] = [
-    "Man and woman lie facing each other, close, legs entwined. He thrusts slowly while looking in her eyes. Closeness allows deep connection.",
-    "Woman straddles man, leaning forward, supporting herself with hands. He enters her from behind. Deep penetration and control for her.",
-    "Man kneels, woman wraps legs around him. He holds her waist, thrusting deeply. Intimacy and eye contact.",
-    "Woman lies on edge of bed, legs lifted. Man stands, entering from above. Depth and pleasure for her, standing power for him.",
-    "Man sits, woman straddles him backwards. She controls pace, he enjoys view.",
-    "Woman leans against wall, man stands behind. He enters, holding her hips. Balance and support for her, dominance for him.",
-    "Man lies, woman straddles, facing away. She sets pace, he watches her reactions.",
-    "Man and woman stand, she wraps legs around him. He lifts, lowers at his pace. Strength and endurance.",
-    "Woman lies, man kneels between legs. He controls depth and speed.",
-    "Woman kneels, man stands behind. He holds her hips, she grabs his arms. Lean, sweaty bodies.",
-    "Man lies, woman on top, facing him. He guides her movements. Eye contact.",
-    "Woman sits, man kneels before her. She controls depth, he licks and kisses.",
-    "Man lies, woman on top, facing away. She sets rhythm, he grips breasts.",
-    "Man sits, woman faces side, straddles. He supports her with arms, she bounces.",
-    "Woman lies, man kneels at side. He enters from above, she spreads legs wide.",
-    "Man and woman sit, facing each other. They move together, slow and sensual.",
-    "Man sits, woman straddles, facing away. He grips thighs, she sets pace.",
-    "Man sits, woman on knees, facing him. He holds her hips, she rocks.",
-    "Man kneels, woman straddles, facing away. She rides fast, he grips buttocks.",
-    "Man sits, woman leans on elbow, facing him. He controls angle, she moves hips.",
-    "Woman stands, man kneels, entering from behind. He holds her waist, she looks back.",
-    "Man kneels, woman sits on lap, facing him. He controls depth, she grinds.",
-    "Woman lies, man kneels, entering from side. He supports her head, she spreads legs.",
-    "Man sits, woman straddles, facing side. He holds her waist, she leans back.",
-    "Man and woman stand, facing each other, he lifts her. He has control, she wraps legs around.",
-    "Woman kneels, man stands, facing her. He holds her hips, she grabs chest.",
-    "Woman sits, man kneels behind. He grips her hips, she rests hands on floor.",
-    "Woman lies, man kneels beside, entering from side. He supports her, she relaxes.",
-    "Man lies, woman kneels, facing him. He grips her waist, she rocks.",
-    "Woman sits, man kneels, facing away. He holds her hips, she grinds.",
-    "Man stands, woman hangs from pull-up bar, he enters from behind. Thrill and danger.",
-    "Man and woman stand, facing each other, he lifts her. She wraps legs around.",
-    "Woman sits, man kneels, facing her. He holds her waist, she grinds.",
-    "Woman lies, man kneels, entering from side. He supports her head, she closes eyes.",
-    "Man sits, woman straddles, facing him. He grips thighs, she moves hips.",
-    "Woman kneels, man stands, facing her. He holds her hips, she touches chest.",
-    "Man lies, woman straddles, facing away. He grips her waist, she sets rhythm.",
-    "Man kneels, woman straddles, facing him. He grips her buttocks, she bounces.",
-    "Woman lies, man kneels, entering from side. He supports her, she arches back.",
-    "Man sits, woman on lap, facing away. He holds her hips, she leans forward.",
-    "Woman sits, man kneels behind. He grips her hips, she braces on hands.",
-    "Man and woman lie side by side, facing same direction. He enters her from behind, shallow strokes. Soft and intimate.",
-    "Woman on hands and knees, man stands behind. He holds her hips, deep penetration. Powerful and animalistic.",
-    "Man and woman stand, she wraps legs around him. He lifts and lowers. Balance and strength.",
-    "Woman lies on back, man kneels between legs. He supports her with hands. Sensitivity and intimacy.",
-    "Man sits, woman straddles, facing away. She sets pace, he caresses breasts.",
-    "Woman crouches, man stands. He grips her hips, she bounces.",
-    "Man lies, woman sits on lap, facing away. He holds her hips, she grinds.",
-    "Man and woman lie face to face, legs entwined. Shallow and sensual.",
-    "Woman kneels, man stands, entering from behind. He holds her hair, she moans.",
-    "Man kneels, woman sits on lap, facing him. He grips her hips, she rocks.",
-    "Woman lies, man kneels beside, entering from side. He supports her head, she closes eyes.",
-    "Woman crouches, man stands, facing her. He holds her hips, she bends forward.",
-    "Man lies, woman on all fours. He enters from behind, dominant.",
-    "Man sits, woman straddles, facing away. He grips her waist, she sets pace.",
-    "Woman kneels, man stands, facing her. He holds her hips, she touches her feet.",
-    "Man lies, woman sits on lap, facing away. He holds her hips, she leans forward.",
-    "Man kneels, woman straddles, facing him. He grips her thighs, she bounces.",
-    "Woman lies, man kneels, entering from side. He supports her head, she arches back.",
-    "Man sits, woman on lap, facing him. He holds her hips, she grinds.",
-    "Woman sits, man kneels behind. He grips her hips, she leans back.",
-    "Man lies, woman sits on lap, facing him. He grips her waist, she rocks.",
-    "Woman kneels, man stands, facing her. He holds her hips, she touches her breasts.",
-    "Man lies, woman straddles, facing away. He grips her buttocks, she sets pace.",
-    "Woman lies, man kneels, entering from side. He supports her, she closes eyes.",
-    "Man kneels, woman straddles, facing him. He grips her waist, she moves hips.",
-    "Man lies, woman on all fours, he enters from behind. Dominant and primal.",
-    "Man sits, woman straddles, facing him. He grips thighs, she sets pace.",
-    "Woman kneels, man stands, facing her. He holds her hips, she touches her toes.",
-    "Man and woman embrace, making love while standing. Their bodies press together as he thrusts into her.",
-    "Woman on top, riding man's hardness. Her movements control the intensity as his hands roam her body.",
-    "Man on back, woman straddling him, facing away. His grip on her waist guides their connection.",
-    "Woman leaning against surface, man behind, filling her. His hands support her as she moans in pleasure.",
-    "Woman sitting, man kneeling before her. She rides his length with controlled ease.",
-    "Man and woman sit facing, moving in a slow dance of desire. Their eyes locked as they connect.",
-    "Woman on man's lap, facing away, taking him in. He watches her reactions to every stroke.",
-    "Man reclining, woman on top, facing him. He admires her beauty while she moves.",
-    "Woman sits, man kneeling, enjoying her every sound. He explores her body with his mouth.",
-    "Woman lying, man kneeling, entering from the side. He cradles her head gently.",
-    "Man sitting, woman straddling, facing him. His hands explore her body as she rides him.",
-    "Woman kneeling, man standing, entering from behind. He grips her hips, pulling her close.",
-    "Man lying, woman straddling, facing away. He reaches for her breasts, guiding her motion.",
-    "Woman sitting, man kneeling, facing her. He enters her slowly, savoring the moment.",
-    "Man kneeling, woman straddling, facing him. He grips her buttocks, matching her rhythm.",
-    "Woman lying, man kneeling, entering from the side. He supports her comfortably.",
-    "Man sitting, woman on lap, facing away. His hands caress her as she leans forward.",
-    "Woman sitting, man kneeling behind. Her hands brace on the floor as he drives deeper.",
-    "Man and woman sitting close, moving in harmony. Their lips meet as they share passion.",
-    "Woman kneeling, man standing, behind her. He whispers sweet nothings in her ear.",
-    "Man lying, woman on top, facing away. He reaches under her, touching her intimately.",
-    "Woman sitting, man kneeling, facing her. He kisses her neck as she rocks on his member.",
-    "Man kneeling, woman straddling, facing him. He massages her back as she rides him.",
-    "Woman lying, man kneeling, entering from the side. He cradles her head, whispering encouragement.",
-    "Man sitting, woman on lap, facing away. He holds her hips, pulling her closer.",
-    "Woman sitting, man kneeling, facing her. He enters her softly, savoring the moment.",
-    "Man kneeling, woman straddling, facing him. He grips her thighs, urging her on.",
-    "Woman lying, man kneeling, entering from the side. He supports her weight, watching her expression.",
-    "Man sitting, woman on lap, facing him. He grips her hips, encouraging her movement.",
-    "Woman kneeling, man standing, behind her. His hands explore her body as she enjoys the sensation.",
-    "Man lying, woman kneeling, facing him. He holds her hips, feeling her muscles clench.",
-    "Woman sitting, man kneeling, facing away. He kisses her neck, matching her pace.",
-    "Man and woman sit facing, intertwining their limbs. Their breaths mingle as they make love.",
-    "Woman crouching, man standing, facing her. He grips her hips, lifting and lowering her.",
-    "Man lying, woman on all fours, taking him deep. He dominates their encounter.",
-    "Man sitting, woman straddling, facing him. He grips her thighs, feeling her heat.",
-    "Woman kneeling, man standing, facing her. He pulls her hair slightly, increasing intensity.",
-    "Man lying, woman on all fours, behind her. He penetrates her deeply, relentlessly.",
-    "Man sitting, woman on lap, facing away. He holds her hips, her sounds fill the room.",
-    "Woman sitting, man kneeling behind. He plays with her nipples, heightening her pleasure.",
-    "Man and woman stand, their bodies entwined. They move together in a passionate frenzy.",
-    "Woman crouching, man standing, facing her. He holds her hips, watching her expressions.",
-    "Man lying, woman on all fours, entering from behind. He gazes at her curves.",
-    "Man sitting, woman straddles, facing him. He kisses her passionately, their tongues intertwine.",
-    "Woman kneeling, man standing, facing her. He grips her hips, their eyes lock.",
-    "Man lying, woman straddling, facing away. He strokes her clit, bringing her closer to climax.",
-    "Man kneeling, woman straddling, facing him. He grips her waist, her moans fill the air.",
-    "Woman lying, man kneeling, entering from the side. He supports her head, their gazes meet."
+    "missionary position",
+    "cowgirl position",
+    "reverse cowgirl",
+    "riding on top",
+    "standing sex",
+    "against the wall",
+    "legs wrapped around waist",
+    "lap sitting sex",
+    "straddling partner",
+    "deep penetration",
+    "grinding hips",
+    "hip thrusting",
+    "side-by-side sex",
+    "spooning sex",
+    "prone bone position",
+    "doggystyle position",
+    "on hands and knees",
+    "from behind",
+    "bent over sex",
+    "arched back sex pose",
+    "full body embrace",
+    "intertwined legs",
+    "lifting partner",
+    "holding ankles",
+    "leaning back in partner's arms",
 ]
 
-# [更新] ユーザー提供の語彙をパースしてリスト化
-_raw_lexicon = [
-    "torogao, rolling eyes, sweat, screaming, spit, fucked silly, mind break, female orgasm, motion lines, aroused, moaning, blush, plap,",
-    "Ahegao, sweat, spit, fucked silly, plap, mind break, female orgasm, rolling eyes, motion lines, aroused, moaning, blush, smile, tongue, tongue out,",
-    " sweat, rolling eyes, spit, fucked silly, plap, mind break, female orgasm, rolling eyes, motion lines, aroused, moaning, blush, rough sex, forced sex, rape,",
-    "sweat, spit, plap, mind break, female orgasm, motion lines, aroused, moaning, blush",
-    "sweat, spit, fucked silly, plap, mind break, female orgasm, motion lines, aroused, moaning, blush",
-    "embarrassed, clenched teeth, sweat, spit, fucked silly, plap, mind break, female orgasm, rolling eyes, motion lines, aroused, moaning, blush,"
-]
-EXPLICIT_SEX_LEXICON: List[str] = _dedupe([tag.strip() for line in _raw_lexicon for tag in line.split(',') if tag.strip()])
+EXPLICIT_SEX_LEXICON: List[str] = _dedupe([
+    "torogao",
+    "rolling eyes",
+    "sweat",
+    "screaming",
+    "spit",
+    "fucked silly",
+    "mind break",
+    "female orgasm",
+    "motion lines",
+    "aroused",
+    "moaning",
+    "blush",
+    "plap",
+    "ahegao",
+    "smile",
+    "tongue",
+    "tongue out",
+    "rough sex",
+    "forced sex",
+    "rape",
+    "embarrassed",
+    "clenched teeth",
+])
 
 EXTRA_EROTIC_POSES: List[str] = [] # 外部読み込み廃止のため空リストに
 
@@ -366,18 +345,13 @@ EXTRA_NSFW_EXPR: List[str] = _merge_unique(
 
 # --- ブロック集合の自動生成 ---
 def _compile_blockset() -> Set[str]:
-    """露骨語をフレーズとサブワードでブロック対象へ。"""
-    base: Set[str] = set()
-    # [更新] rape, forced sex などの特に強い単語を明示的にブロックリストへ追加
+    """露骨語を明示的な単語リストでブロック対象へ。"""
     manual_block_words = {"rape", "forced sex"}
-    base.update(manual_block_words)
-
-    for s in _merge_unique(EXPLICIT_SEX_LEXICON, EXPLICIT_SEX_POSES):
-        low = s.lower()
-        base.add(low)
-        for w in re.split(r"[^a-zA-Z0-9]+", low):
-            if len(w) >= 8: # 一定文字数以上の単語をブロック対象に追加
-                base.add(w)
+    base: Set[str] = {word.lower() for word in manual_block_words}
+    for tag in _merge_unique(EXPLICIT_SEX_LEXICON, EXPLICIT_SEX_POSES):
+        if not tag:
+            continue
+        base.add(tag.lower())
     return base
 
 EXPLICIT_BLOCKLIST: Set[str] = _compile_blockset()


### PR DESCRIPTION
## Summary
- unify theme pack definitions under a richer EMOTION_THEME_PACKS schema that carries tags, focus and conflicts metadata
- replace narrative explicit pose strings with reusable tag phrases and a cleaned NSFW lexicon backed by an explicit blocklist
- update pose_emotion_tag helpers to consume the new theme schema and conflict metadata when assembling prompts

## Testing
- python -m compileall pose_emotion_tag.py vocab/pose_emotion_vocab.py

------
https://chatgpt.com/codex/tasks/task_e_68d792812ee08326adb30c40009a5f09