### PR TITLE
Refactor appearance tag generation

### DIFF
--- a/appearance_tag.py
+++ b/appearance_tag.py
@@ -1,93 +1,279 @@
 # appearance_tag.py
-# 体型 + 胸サイズ + 髪タグ（長さ/質感/スタイル/前髪・分け目/色/色ミックス）統合ノード
-# - clothing_tag の設計を踏襲し確率/UI/テーマ拡張に対応
-# - kawaii テーマに petite 系（childlike 等）を集約
-# - 胸サイズは段階 + ソフト/NSFW オプションを独立確率で制御
+# 顔造形・体型・髪を多段階で生成するノード
 
-from typing import List
+from typing import Dict, List, Optional, Sequence, Tuple
+
 from .util import (
-    rng_from_seed, maybe, pick, join_clean, limit_len, normalize, merge_unique
+    rng_from_seed,
+    maybe,
+    pick,
+    join_clean,
+    limit_len,
+    normalize,
+    merge_unique,
 )
 from .vocab.appearance_vocab import (
-    BODY_BASE, BODY_DETAILS,
-    BUST_SIZES, BUST_OPTIONS_SOFT, BUST_OPTIONS_NSFW,
-    HAIR_LENGTHS, HAIR_TEXTURES, HAIR_ARRANGEMENTS, HAIR_BANGS_PART,
-    HAIR_COLORS, HAIR_COLOR_MIX,
+    BODY_SHAPES,
+    BODY_DETAILS,
+    SKIN_DETAILS,
+    HAIR_LENGTHS,
+    HAIR_TEXTURES,
+    HAIR_STYLES,
+    HAIR_BANGS_PART,
+    HAIR_COLORS,
+    HAIR_COLOR_MIX,
+    FACE_SHAPES,
+    FACE_DETAILS,
+    EYE_SHAPES,
+    NOSE_SHAPES,
+    LIP_SHAPES,
+    BODY_ACCENTS,
+    SKIN_ACCENTS,
+    FACE_ACCENTS,
+    HAIR_ACCENTS,
+    SENSUAL_ACCENTS,
     THEMES,
+    EXCLUSIVE_GROUPS,
 )
 
-# ===== UIラベル =====
+
 MODE_MAP_JP = {"一般": "normal", "セクシー": "sexy"}
 THEME_CHOICES = ["none"] + sorted(list(THEMES.keys()))
 
-# ===== テーマ適用 =====
-def _apply_themes(base: dict, theme_keys: List[str]) -> dict:
-    b = base.copy()
-    for k in theme_keys:
-        t = THEMES.get(k, {})
-        if t:
-            b["body_bias"] = merge_unique(b.get("body_bias", []), t.get("body_bias", []))
-            b["hair_bias"] = merge_unique(b.get("hair_bias", []), t.get("hair_bias", []))
-    return b
 
-def _prepare_lists(theme_keys: List[str]) -> dict:
-    base = dict(
-        body_base=BODY_BASE,
-        body_details=BODY_DETAILS,
-        bust_sizes=BUST_SIZES,
-        bust_soft=BUST_OPTIONS_SOFT,
-        bust_nsfw=BUST_OPTIONS_NSFW,
-        hair_lengths=HAIR_LENGTHS,
-        hair_textures=HAIR_TEXTURES,
-        hair_arr=HAIR_ARRANGEMENTS,
-        hair_bangs=HAIR_BANGS_PART,
-        hair_colors=HAIR_COLORS,
-        hair_mix=HAIR_COLOR_MIX,
-        body_bias=[],
-        hair_bias=[],
+def _copy_list(values: Sequence[str]) -> List[str]:
+    return list(values or [])
+
+
+def _prepare_vocab(theme_keys: List[str]) -> Dict[str, List[str]]:
+    vocab = dict(
+        body_shapes=_copy_list(BODY_SHAPES),
+        body_details=_copy_list(BODY_DETAILS),
+        skin_tones=_copy_list(SKIN_DETAILS.get("tones", [])),
+        skin_features=_copy_list(SKIN_DETAILS.get("features", [])),
+        skin_finishes=_copy_list(SKIN_DETAILS.get("finishes", [])),
+        hair_lengths=_copy_list(HAIR_LENGTHS),
+        hair_textures=_copy_list(HAIR_TEXTURES),
+        hair_styles=_copy_list(HAIR_STYLES),
+        hair_bangs=_copy_list(HAIR_BANGS_PART),
+        hair_colors=_copy_list(HAIR_COLORS),
+        hair_color_mix=_copy_list(HAIR_COLOR_MIX),
+        face_shapes=_copy_list(FACE_SHAPES),
+        eye_shapes=_copy_list(EYE_SHAPES),
+        nose_shapes=_copy_list(NOSE_SHAPES),
+        lip_shapes=_copy_list(LIP_SHAPES),
+        face_details=_copy_list(FACE_DETAILS),
+        body_accents=_copy_list(BODY_ACCENTS),
+        skin_accents=_copy_list(SKIN_ACCENTS),
+        face_accents=_copy_list(FACE_ACCENTS),
+        hair_accents=_copy_list(HAIR_ACCENTS),
+        body_shape_bias=[],
+        body_detail_bias=[],
+        skin_tone_bias=[],
+        skin_feature_bias=[],
+        hair_length_bias=[],
+        hair_texture_bias=[],
+        hair_style_bias=[],
+        hair_bang_bias=[],
+        hair_color_bias=[],
+        hair_mix_bias=[],
+        face_shape_bias=[],
+        eye_shape_bias=[],
+        nose_shape_bias=[],
+        lip_shape_bias=[],
+        face_detail_bias=[],
+        decor_body_bias=[],
+        decor_skin_bias=[],
+        decor_face_bias=[],
+        decor_hair_bias=[],
     )
-    if theme_keys:
-        base = _apply_themes(base, theme_keys)
-    return base
 
-# ===== 合成ロジック =====
-def _compose_body(rng, p, L, sexy: bool) -> str:
-    # テーマ体型バイアスを優先的に採用（確率）
-    base_bias = pick(rng, L.get("body_bias", [])) if L.get("body_bias") and maybe(rng, p["p_body_bias"]) else None
-    base      = base_bias or pick(rng, L["body_base"]) or "balanced physique"
+    for key in theme_keys:
+        theme = THEMES.get(key)
+        if not theme:
+            continue
 
-    detail    = pick(rng, L["body_details"]) if maybe(rng, p["p_body_detail"]) else None
-    bust      = pick(rng, L["bust_sizes"])   if maybe(rng, p["p_bust"]) else None
+        body = theme.get("body", {})
+        if body:
+            vocab["body_shapes"] = merge_unique(vocab["body_shapes"], body.get("shapes", []))
+            vocab["body_details"] = merge_unique(vocab["body_details"], body.get("details", []))
+            vocab["body_shape_bias"] = merge_unique(vocab["body_shape_bias"], body.get("shapes", []))
+            vocab["body_detail_bias"] = merge_unique(vocab["body_detail_bias"], body.get("details", []))
 
-    bust_soft = pick(rng, L["bust_soft"]) if bust and maybe(rng, p["p_bust_soft"]) else None
-    bust_nsfw = pick(rng, L["bust_nsfw"]) if sexy and bust and maybe(rng, p["p_bust_nsfw"]) else None
+        skin = theme.get("skin", {})
+        if skin:
+            vocab["skin_tones"] = merge_unique(vocab["skin_tones"], skin.get("tones", []))
+            vocab["skin_features"] = merge_unique(vocab["skin_features"], skin.get("features", []))
+            vocab["skin_finishes"] = merge_unique(vocab["skin_finishes"], skin.get("finishes", []))
+            vocab["skin_tone_bias"] = merge_unique(vocab["skin_tone_bias"], skin.get("tones", []))
+            vocab["skin_feature_bias"] = merge_unique(vocab["skin_feature_bias"], skin.get("features", []))
 
-    parts = [base, detail, bust, bust_soft, bust_nsfw]
-    return join_clean([x for x in parts if x], sep=" ")
+        hair = theme.get("hair", {})
+        if hair:
+            vocab["hair_lengths"] = merge_unique(vocab["hair_lengths"], hair.get("lengths", []))
+            vocab["hair_textures"] = merge_unique(vocab["hair_textures"], hair.get("textures", []))
+            vocab["hair_styles"] = merge_unique(vocab["hair_styles"], hair.get("styles", []))
+            vocab["hair_bangs"] = merge_unique(vocab["hair_bangs"], hair.get("bangs", []))
+            vocab["hair_colors"] = merge_unique(vocab["hair_colors"], hair.get("colors", []))
+            vocab["hair_color_mix"] = merge_unique(vocab["hair_color_mix"], hair.get("mix", []))
+            vocab["hair_length_bias"] = merge_unique(vocab["hair_length_bias"], hair.get("lengths", []))
+            vocab["hair_texture_bias"] = merge_unique(vocab["hair_texture_bias"], hair.get("textures", []))
+            vocab["hair_style_bias"] = merge_unique(vocab["hair_style_bias"], hair.get("styles", []))
+            vocab["hair_bang_bias"] = merge_unique(vocab["hair_bang_bias"], hair.get("bangs", []))
+            vocab["hair_color_bias"] = merge_unique(vocab["hair_color_bias"], hair.get("colors", []))
+            vocab["hair_mix_bias"] = merge_unique(vocab["hair_mix_bias"], hair.get("mix", []))
 
-def _compose_hair(rng, p, L) -> str:
-    # 色ミックス or 単色（排他）
-    color = None
-    if maybe(rng, p["p_hair_color_mix"]):
-        color = pick(rng, L["hair_mix"])
-    if not color and maybe(rng, p["p_hair_color"]):
-        color = pick(rng, L["hair_colors"])
+        face = theme.get("face", {})
+        if face:
+            vocab["face_shapes"] = merge_unique(vocab["face_shapes"], face.get("shapes", []))
+            vocab["eye_shapes"] = merge_unique(vocab["eye_shapes"], face.get("eyes", []))
+            vocab["nose_shapes"] = merge_unique(vocab["nose_shapes"], face.get("nose", []))
+            vocab["lip_shapes"] = merge_unique(vocab["lip_shapes"], face.get("lips", []))
+            vocab["face_details"] = merge_unique(vocab["face_details"], face.get("details", []))
+            vocab["face_shape_bias"] = merge_unique(vocab["face_shape_bias"], face.get("shapes", []))
+            vocab["eye_shape_bias"] = merge_unique(vocab["eye_shape_bias"], face.get("eyes", []))
+            vocab["nose_shape_bias"] = merge_unique(vocab["nose_shape_bias"], face.get("nose", []))
+            vocab["lip_shape_bias"] = merge_unique(vocab["lip_shape_bias"], face.get("lips", []))
+            vocab["face_detail_bias"] = merge_unique(vocab["face_detail_bias"], face.get("details", []))
 
-    length  = pick(rng, L["hair_lengths"])  if maybe(rng, p["p_hair_length"])  else None
-    texture = pick(rng, L["hair_textures"]) if maybe(rng, p["p_hair_texture"]) else None
-    arr     = pick(rng, L["hair_arr"])      if maybe(rng, p["p_hair_arr"])     else None
-    bangs   = pick(rng, L["hair_bangs"])    if maybe(rng, p["p_hair_bangs"])   else None
+        decor = theme.get("decor", {})
+        if decor:
+            vocab["body_accents"] = merge_unique(vocab["body_accents"], decor.get("body", []))
+            vocab["skin_accents"] = merge_unique(vocab["skin_accents"], decor.get("skin", []))
+            vocab["face_accents"] = merge_unique(vocab["face_accents"], decor.get("face", []))
+            vocab["hair_accents"] = merge_unique(vocab["hair_accents"], decor.get("hair", []))
+            vocab["decor_body_bias"] = merge_unique(vocab["decor_body_bias"], decor.get("body", []))
+            vocab["decor_skin_bias"] = merge_unique(vocab["decor_skin_bias"], decor.get("skin", []))
+            vocab["decor_face_bias"] = merge_unique(vocab["decor_face_bias"], decor.get("face", []))
+            vocab["decor_hair_bias"] = merge_unique(vocab["decor_hair_bias"], decor.get("hair", []))
 
-    # テーマ髪バイアス（例: kawaii -> twin tails / curtain bangs など）
-    bias = pick(rng, L["hair_bias"]) if L.get("hair_bias") and maybe(rng, p["p_hair_bias"]) else None
+    return vocab
 
-    head = join_clean([length, texture, arr, bias], sep=" ")
-    if head:
-        head = head + " hair"
 
-    return join_clean([color, head, bangs], sep=" ")
+def _get_exclusive_tags(first_tag: str) -> List[str]:
+    blocked: List[str] = []
+    for groups in EXCLUSIVE_GROUPS.values():
+        for tags in groups.values():
+            if first_tag in tags:
+                for other_tags in groups.values():
+                    blocked.extend(other_tags)
+                break
+    return blocked
 
-# ===== ノード本体 =====
+
+def _add_tag(collector: List[str], exclusive: set, tag: Optional[str], alias: Optional[Sequence[str]] = None) -> bool:
+    if not tag:
+        return False
+    alias_list = [tag]
+    if alias:
+        alias_list.extend([a for a in alias if a])
+    if any(a in exclusive for a in alias_list):
+        return False
+    collector.append(tag)
+    for item in alias_list:
+        exclusive.add(item)
+        for blocked in _get_exclusive_tags(item):
+            exclusive.add(blocked)
+    return True
+
+
+def _register_choice(exclusive: set, choice: Optional[str]) -> None:
+    if not choice:
+        return
+    exclusive.add(choice)
+    for blocked in _get_exclusive_tags(choice):
+        exclusive.add(blocked)
+
+
+def _choose_with_bias(rng, pool: List[str], bias: List[str], probability: float) -> Optional[str]:
+    if bias and maybe(rng, probability):
+        candidate = pick(rng, bias)
+        if candidate:
+            return candidate
+    return pick(rng, pool)
+
+
+def _scaled_prob(base: float, maximum: float, factor: float) -> float:
+    factor = max(0.0, min(1.0, factor))
+    return base + (maximum - base) * factor
+
+
+def _format_hair_length(length: Optional[str]) -> Optional[str]:
+    if not length:
+        return None
+    if "cut" in length or "bob" in length:
+        return length
+    return f"{length} hair"
+
+
+def _format_hair_texture(texture: Optional[str]) -> Optional[str]:
+    if not texture:
+        return None
+    if "hair" in texture:
+        return texture
+    return f"{texture} hair"
+
+
+def _format_hair_color(color: Optional[str]) -> Optional[str]:
+    if not color:
+        return None
+    if any(word in color for word in ["balayage", "ombre", "streaks", "gradient", "highlights", "melt"]):
+        return color
+    if "hair" in color:
+        return color
+    return f"{color} hair"
+
+
+def _pick_from_pool(rng, pool: List[str], bias: List[str], probability: float, exclusive: set) -> Optional[str]:
+    available = [t for t in pool if t not in exclusive]
+    if not available:
+        return None
+    biased = [t for t in bias if t in available]
+    return _choose_with_bias(rng, available, biased, probability)
+
+
+def _stage_three_enrich(
+    rng,
+    tags: List[str],
+    exclusive: set,
+    vocab: Dict[str, List[str]],
+    body_complexity: float,
+    face_complexity: float,
+    sexy: bool,
+    max_len: int,
+) -> None:
+    stage_sources: List[Tuple[str, List[str], List[str], float]] = [
+        ("body", vocab["body_accents"], vocab["decor_body_bias"], _scaled_prob(0.25, 0.7, body_complexity)),
+        ("skin", vocab["skin_accents"], vocab["decor_skin_bias"], _scaled_prob(0.3, 0.85, body_complexity)),
+        ("face", vocab["face_accents"], vocab["decor_face_bias"], _scaled_prob(0.35, 0.9, face_complexity)),
+        ("hair", vocab["hair_accents"], vocab["decor_hair_bias"], _scaled_prob(0.3, 0.75, face_complexity)),
+    ]
+    if sexy:
+        stage_sources.append(("sensual", _copy_list(SENSUAL_ACCENTS), [], 0.45))
+
+    attempts_without_progress = 0
+    while stage_sources and len(join_clean(tags)) < max_len and attempts_without_progress < 8:
+        category, pool, bias, probability = rng.choice(stage_sources)
+        if not pool:
+            stage_sources.remove((category, pool, bias, probability))
+            continue
+        available = [t for t in pool if t not in exclusive and t not in tags]
+        if not available or not maybe(rng, probability):
+            attempts_without_progress += 1
+            continue
+        biased = [t for t in bias if t in available]
+        candidate = _choose_with_bias(rng, available, biased, probability)
+        if not candidate:
+            attempts_without_progress += 1
+            continue
+        prospective = join_clean(tags + [candidate])
+        if max_len and len(prospective) > max_len:
+            attempts_without_progress += 1
+            continue
+        _add_tag(tags, exclusive, candidate)
+        attempts_without_progress = 0
+
+
 class AppearanceTagNode:
     @classmethod
     def INPUT_TYPES(cls):
@@ -96,31 +282,14 @@ class AppearanceTagNode:
                 "seed": ("INT", {"default": 42, "min": 0, "max": 2**31 - 1}),
             },
             "optional": {
-                # テーマ/モード
                 "モード": (list(MODE_MAP_JP.keys()), {"default": "一般"}),
                 "テーマ1": (THEME_CHOICES, {"default": "none"}),
                 "テーマ2": (THEME_CHOICES, {"default": "none"}),
                 "テーマ3": (THEME_CHOICES, {"default": "none"}),
-
-                # 出力整形
-                "最大文字数": ("INT", {"default": 120, "min": 0, "max": 4096}),
+                "最大文字数": ("INT", {"default": 160, "min": 0, "max": 4096}),
                 "小文字化": ("BOOL", {"default": True}),
-
-                # 体型/胸 確率
-                "確率: テーマ体型バイアス": ("FLOAT", {"default": 0.35, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 体型詳細": ("FLOAT", {"default": 0.55, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 胸サイズ": ("FLOAT", {"default": 0.80, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 胸オプション(ソフト)": ("FLOAT", {"default": 0.40, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 胸オプション(NSFW)": ("FLOAT", {"default": 0.15, "min": 0.0, "max": 1.0, "step": 0.01}),
-
-                # 髪 確率
-                "確率: 髪の長さ": ("FLOAT", {"default": 0.90, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 髪質/仕上げ": ("FLOAT", {"default": 0.75, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 髪スタイル": ("FLOAT", {"default": 0.60, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 前髪/分け目": ("FLOAT", {"default": 0.55, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 髪色(単色)": ("FLOAT", {"default": 0.65, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: 髪色(ミックス)": ("FLOAT", {"default": 0.25, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "確率: テーマ髪バイアス": ("FLOAT", {"default": 0.35, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "顔の造形の複雑さ": ("FLOAT", {"default": 0.65, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "身体的特徴の複雑さ": ("FLOAT", {"default": 0.55, "min": 0.0, "max": 1.0, "step": 0.01}),
             },
         }
 
@@ -129,49 +298,241 @@ class AppearanceTagNode:
     CATEGORY = "Text/Wildcards"
 
     def generate(
-        self, seed,
-        モード="一般", テーマ1="none", テーマ2="none", テーマ3="none",
-        最大文字数=120, 小文字化=True,
-        確率_テーマ体型バイアス=0.35, 確率_体型詳細=0.55,
-        確率_胸サイズ=0.80, 確率_胸オプション_ソフト=0.40, 確率_胸オプション_NSFW=0.15,
-        確率_髪の長さ=0.90, 確率_髪質_仕上げ=0.75, 確率_髪スタイル=0.60, 確率_前髪_分け目=0.55,
-        確率_髪色_単色=0.65, 確率_髪色_ミックス=0.25, 確率_テーマ髪バイアス=0.35,
-        **kwargs
+        self,
+        seed: int,
+        モード: str = "一般",
+        テーマ1: str = "none",
+        テーマ2: str = "none",
+        テーマ3: str = "none",
+        最大文字数: int = 160,
+        小文字化: bool = True,
+        顔の造形の複雑さ: float = 0.65,
+        身体的特徴の複雑さ: float = 0.55,
+        **kwargs,
     ):
         rng = rng_from_seed(seed)
-        sexy = (MODE_MAP_JP.get(モード, "normal") == "sexy")
+        sexy = MODE_MAP_JP.get(モード, "normal") == "sexy"
 
-        # テーマキー整理
-        keys = []
-        for k in [テーマ1, テーマ2, テーマ3]:
-            if k and k != "none" and k in THEMES and k not in keys:
-                keys.append(k)
+        theme_keys = []
+        for key in [テーマ1, テーマ2, テーマ3]:
+            if key and key != "none" and key in THEMES and key not in theme_keys:
+                theme_keys.append(key)
 
-        L = _prepare_lists(keys)
+        vocab = _prepare_vocab(theme_keys)
 
-        p = dict(
-            # 体型/胸
-            p_body_bias=確率_テーマ体型バイアス,
-            p_body_detail=確率_体型詳細,
-            p_bust=確率_胸サイズ,
-            p_bust_soft=確率_胸オプション_ソフト,
-            p_bust_nsfw=確率_胸オプション_NSFW,
-            # 髪
-            p_hair_length=確率_髪の長さ,
-            p_hair_texture=確率_髪質_仕上げ,
-            p_hair_arr=確率_髪スタイル,
-            p_hair_bangs=確率_前髪_分け目,
-            p_hair_color=確率_髪色_単色,
-            p_hair_color_mix=確率_髪色_ミックス,
-            p_hair_bias=確率_テーマ髪バイアス,
+        face_complexity = max(0.0, min(1.0, 顔の造形の複雑さ))
+        body_complexity = max(0.0, min(1.0, 身体的特徴の複雑さ))
+
+        tags: List[str] = []
+        exclusive_tags: set = set()
+
+        # ===== Stage 1: Core traits =====
+        body_shape = _pick_from_pool(
+            rng,
+            vocab["body_shapes"],
+            vocab["body_shape_bias"],
+            _scaled_prob(0.35, 0.7, body_complexity),
+            exclusive_tags,
+        )
+        _add_tag(tags, exclusive_tags, body_shape)
+
+        skin_tone = _pick_from_pool(
+            rng,
+            vocab["skin_tones"],
+            vocab["skin_tone_bias"],
+            _scaled_prob(0.4, 0.85, body_complexity),
+            exclusive_tags,
+        )
+        _add_tag(tags, exclusive_tags, skin_tone)
+
+        face_shape = _pick_from_pool(
+            rng,
+            vocab["face_shapes"],
+            vocab["face_shape_bias"],
+            _scaled_prob(0.45, 0.85, face_complexity),
+            exclusive_tags,
+        )
+        _add_tag(tags, exclusive_tags, face_shape)
+
+        hair_length_choice = _pick_from_pool(
+            rng,
+            vocab["hair_lengths"],
+            vocab["hair_length_bias"],
+            _scaled_prob(0.35, 0.7, face_complexity),
+            exclusive_tags,
+        )
+        _register_choice(exclusive_tags, hair_length_choice)
+
+        color_mix_probability = _scaled_prob(0.2, 0.55, face_complexity)
+        hair_mix_choice = None
+        if maybe(rng, color_mix_probability):
+            hair_mix_choice = _pick_from_pool(
+                rng,
+                vocab["hair_color_mix"],
+                vocab["hair_mix_bias"],
+                min(0.9, color_mix_probability + 0.25),
+                exclusive_tags,
+            )
+        hair_color_choice = None
+        if not hair_mix_choice:
+            hair_color_choice = _pick_from_pool(
+                rng,
+                vocab["hair_colors"],
+                vocab["hair_color_bias"],
+                0.85,
+                exclusive_tags,
+            )
+        _register_choice(exclusive_tags, hair_mix_choice or hair_color_choice)
+
+        # ===== Stage 2: Detailed traits =====
+        body_detail_prob = _scaled_prob(0.3, 0.75, body_complexity)
+        body_detail = _pick_from_pool(
+            rng,
+            vocab["body_details"],
+            vocab["body_detail_bias"],
+            body_detail_prob,
+            exclusive_tags,
+        )
+        _add_tag(tags, exclusive_tags, body_detail)
+
+        skin_feature_prob = _scaled_prob(0.25, 0.75, body_complexity)
+        if maybe(rng, skin_feature_prob):
+            skin_feature = _pick_from_pool(
+                rng,
+                vocab["skin_features"],
+                vocab["skin_feature_bias"],
+                skin_feature_prob,
+                exclusive_tags,
+            )
+            _add_tag(tags, exclusive_tags, skin_feature)
+
+        skin_finish_prob = _scaled_prob(0.3, 0.8, body_complexity)
+        if maybe(rng, skin_finish_prob):
+            skin_finish = _pick_from_pool(
+                rng,
+                vocab["skin_finishes"],
+                [],
+                skin_finish_prob,
+                exclusive_tags,
+            )
+            _add_tag(tags, exclusive_tags, skin_finish)
+
+        eye_shape = _pick_from_pool(
+            rng,
+            vocab["eye_shapes"],
+            vocab["eye_shape_bias"],
+            _scaled_prob(0.4, 0.85, face_complexity),
+            exclusive_tags,
+        )
+        _add_tag(tags, exclusive_tags, eye_shape)
+
+        nose_shape = _pick_from_pool(
+            rng,
+            vocab["nose_shapes"],
+            vocab["nose_shape_bias"],
+            _scaled_prob(0.35, 0.8, face_complexity),
+            exclusive_tags,
+        )
+        _add_tag(tags, exclusive_tags, nose_shape)
+
+        lip_shape = _pick_from_pool(
+            rng,
+            vocab["lip_shapes"],
+            vocab["lip_shape_bias"],
+            _scaled_prob(0.35, 0.85, face_complexity),
+            exclusive_tags,
+        )
+        _add_tag(tags, exclusive_tags, lip_shape)
+
+        face_detail_prob = _scaled_prob(0.35, 0.8, face_complexity)
+        if maybe(rng, face_detail_prob):
+            face_detail = _pick_from_pool(
+                rng,
+                vocab["face_details"],
+                vocab["face_detail_bias"],
+                face_detail_prob,
+                exclusive_tags,
+            )
+            if _add_tag(tags, exclusive_tags, face_detail):
+                # chance for a secondary complementary detail when complexity is high
+                if maybe(rng, face_complexity * 0.35):
+                    secondary_detail = _pick_from_pool(
+                        rng,
+                        vocab["face_details"],
+                        vocab["face_detail_bias"],
+                        face_detail_prob * 0.8,
+                        exclusive_tags,
+                    )
+                    _add_tag(tags, exclusive_tags, secondary_detail)
+
+        hair_texture_prob = _scaled_prob(0.4, 0.8, face_complexity)
+        if maybe(rng, hair_texture_prob):
+            hair_texture_choice = _pick_from_pool(
+                rng,
+                vocab["hair_textures"],
+                vocab["hair_texture_bias"],
+                hair_texture_prob,
+                exclusive_tags,
+            )
+            _register_choice(exclusive_tags, hair_texture_choice)
+            hair_texture_tag = _format_hair_texture(hair_texture_choice)
+            _add_tag(tags, exclusive_tags, hair_texture_tag, alias=[hair_texture_choice] if hair_texture_choice else None)
+
+        hair_style_prob = _scaled_prob(0.35, 0.75, face_complexity)
+        if maybe(rng, hair_style_prob):
+            hair_style_choice = _pick_from_pool(
+                rng,
+                vocab["hair_styles"],
+                vocab["hair_style_bias"],
+                hair_style_prob,
+                exclusive_tags,
+            )
+            _register_choice(exclusive_tags, hair_style_choice)
+            _add_tag(tags, exclusive_tags, hair_style_choice)
+
+        hair_bang_prob = _scaled_prob(0.35, 0.75, face_complexity)
+        if maybe(rng, hair_bang_prob):
+            hair_bang_choice = _pick_from_pool(
+                rng,
+                vocab["hair_bangs"],
+                vocab["hair_bang_bias"],
+                hair_bang_prob,
+                exclusive_tags,
+            )
+            _register_choice(exclusive_tags, hair_bang_choice)
+            _add_tag(tags, exclusive_tags, hair_bang_choice)
+
+        hair_length_tag = _format_hair_length(hair_length_choice)
+        _add_tag(
+            tags,
+            exclusive_tags,
+            hair_length_tag,
+            alias=[hair_length_choice] if hair_length_choice else None,
         )
 
-        body = _compose_body(rng, p, L, sexy)
-        hair = _compose_hair(rng, p, L)
+        hair_color_tag = _format_hair_color(hair_mix_choice or hair_color_choice)
+        _add_tag(
+            tags,
+            exclusive_tags,
+            hair_color_tag,
+            alias=[hair_mix_choice or hair_color_choice] if (hair_mix_choice or hair_color_choice) else None,
+        )
 
-        tag = join_clean([body, hair], sep=" ")
-        tag = normalize(tag, 小文字化)
-        tag = limit_len(tag, 最大文字数)
-        return (tag,)
+        # ===== Stage 3: Fill up to max length =====
+        _stage_three_enrich(
+            rng,
+            tags,
+            exclusive_tags,
+            vocab,
+            body_complexity,
+            face_complexity,
+            sexy,
+            最大文字数,
+        )
+
+        tag_string = join_clean(tags)
+        tag_string = normalize(tag_string, 小文字化)
+        tag_string = limit_len(tag_string, 最大文字数)
+        return (tag_string,)
 
 

--- a/vocab/appearance_vocab.py
+++ b/vocab/appearance_vocab.py
@@ -1,179 +1,405 @@
 # vocab/appearance_vocab.py
-# 統合語彙: 体型 + 胸サイズ + 髪（長さ/質感/スタイル/前髪・分け目/色/色ミックス）+ テーマバイアス
-# - 「美人寄り」の審美語彙をベースに、kawaii テーマへ petite 系（childlike 等）を集約
-# - 髪は「単色 or ミックス」を排他的に選択しやすいよう代表値を厳選
-# - 胸サイズは段階 + 付随属性（NSFW 寄りは別確率）で制御
+# 外見（体・肌・顔・髪）タグ用語彙の刷新版
 
-# ===== Body（体型） =====
-BODY_BASE = [
-    # 美人寄り・審美的で中立的な語彙
-    "slender yet toned",
-    "graceful silhouette",
-    "elegant curves",
-    "balanced physique",
-    "hourglass figure",
-    "model-like proportions",
-    "petite yet elegant",
-    "tall and graceful",
+# ===== Body =====
+BODY_SHAPES = [
+    "slender frame",
+    "athletic build",
+    "graceful curves",
+    "petite frame",
+    "statuesque form",
+    "hourglass silhouette",
+    "softly rounded figure",
+    "toned dancer physique",
+    "delicate build",
 ]
 
 BODY_DETAILS = [
     "defined waistline",
     "long elegant legs",
-    "feminine shoulders",
-    "subtle curves",
-    "radiant posture",
+    "sculpted abs",
+    "soft shoulders",
+    "delicate collarbones",
+    "balletic posture",
+    "lithe limbs",
+    "graceful neck",
 ]
 
-# ===== Bust（胸） =====
-# 段階表現（過度なスラング/扇情的俗語は避けた表現）
-BUST_SIZES = [
-    "flat chest",
-    "small breasts",
-    "medium breasts",
-    "large breasts",
-    "extra large breasts",
-]
+SKIN_DETAILS = {
+    "tones": [
+        "porcelain skin",
+        "pale rosy skin",
+        "fair neutral skin",
+        "warm beige skin",
+        "golden olive skin",
+        "sun-kissed tan skin",
+        "bronzed skin",
+        "deep cocoa skin",
+        "rich ebony skin",
+    ],
+    "features": [
+        "dusting of freckles",
+        "delicate freckles",
+        "rosy cheeks",
+        "soft blush",
+        "beauty mark below eye",
+        "beauty mark near lips",
+        "subtle sun spots",
+        "mole on cheek",
+    ],
+    "finishes": [
+        "dewy complexion",
+        "luminous glow",
+        "velvety smooth skin",
+        "matte porcelain finish",
+        "radiant sheen",
+    ],
+}
 
-# 付随属性（ソフト系）：自然で審美的な付加情報
-BUST_OPTIONS_SOFT = [
-    "natural shape",
-    "subtle lift",
-    "full bust",
-    "firm",
-]
-
-# 付随属性（NSFW寄り）：独立確率で低めに運用
-BUST_OPTIONS_NSFW = [
-    "sagging breasts",
-    "puffy nipples",
-]
-
-# ===== Hair（髪） =====
-# 長さ：冗長さを避けた代表値（原資料から正規化）
+# ===== Hair =====
 HAIR_LENGTHS = [
     "pixie cut",
-    "short",
-    "bob",
-    "lob",
+    "short crop",
+    "chin-length bob",
     "shoulder-length",
     "collarbone-length",
-    "long",
-    "very long",
+    "mid-back length",
     "waist-length",
+    "hip-length",
 ]
 
-# 質感/仕上げ：質感とフィニッシュを混ぜて運用（タグ数の伸びを抑える）
 HAIR_TEXTURES = [
-    "straight",
-    "wavy",
-    "curly",
-    "silky smooth",
-    "voluminous waves",
-    "luxurious curls",
-    "soft straight",
-    "glossy",
-    "shiny",
-    "natural",
+    "sleek straight",
+    "silky straight",
+    "soft wavy",
+    "gentle waves",
+    "loose curls",
+    "defined curls",
+    "spiral curls",
+    "coily texture",
+    "fluffy volume",
+    "smooth layers",
 ]
 
-# スタイル/アレンジ
-HAIR_ARRANGEMENTS = [
-    "elegant updo",
+HAIR_STYLES = [
+    "loose flowing",
     "half-up half-down",
-    "loose ponytail",
+    "twin tails",
     "high ponytail",
     "low ponytail",
-    "side braid",
-    "braided updo",
+    "side ponytail",
+    "loose braid",
+    "braided crown",
     "messy bun",
-    "twin tails",
+    "elegant updo",
 ]
 
-# 前髪/分け目
 HAIR_BANGS_PART = [
     "no bangs",
     "wispy bangs",
-    "curtain bangs",
     "soft fringe",
-    "side-swept bangs",
+    "curtain bangs",
     "blunt bangs",
+    "side-swept bangs",
     "middle part",
+    "off-center part",
     "deep side part",
 ]
 
-# 単色（代表値）
 HAIR_COLORS = [
-    "black",
+    "jet black",
+    "blue-black",
     "dark brown",
-    "light brown",
-    "blonde",
+    "chocolate brown",
+    "chestnut brown",
+    "auburn",
+    "copper",
+    "honey blonde",
+    "strawberry blonde",
     "platinum blonde",
     "ash blonde",
-    "auburn",
-    "burgundy",
-    "chestnut",
-    "copper",
-    "rose gold",
+    "silver gray",
+    "rose pink",
+    "lavender",
+    "teal",
 ]
 
-# ミックス/バレイヤージュ系（代表値）※単色とは排他運用を想定
 HAIR_COLOR_MIX = [
-    "chocolate and caramel",
-    "honey and brown",
-    "rose gold and blonde",
-    "jet black and blonde",
-    "emerald green and blonde",
-    "cobalt blue and blonde",
+    "caramel and chestnut balayage",
+    "honey and chocolate highlights",
+    "rose gold ombre",
+    "peach and blonde gradient",
+    "silver and lavender melt",
+    "black and crimson streaks",
+    "teal and blue balayage",
 ]
 
-# ===== Themes（テーマ） =====
-# - body_bias: 体型の出目に傾きを与えるバイアス
-# - hair_bias: 髪の出目に傾きを与えるバイアス（appearance_tag 側で確率適用）
+# ===== Face =====
+FACE_SHAPES = [
+    "oval face",
+    "round face",
+    "heart-shaped face",
+    "diamond-shaped face",
+    "square face",
+    "long face",
+    "triangle face",
+]
+
+EYE_SHAPES = [
+    "almond eyes",
+    "round eyes",
+    "upturned eyes",
+    "downturned eyes",
+    "monolid eyes",
+    "hooded eyes",
+    "deep-set eyes",
+    "wide-set eyes",
+    "narrow eyes",
+]
+
+NOSE_SHAPES = [
+    "straight nose",
+    "button nose",
+    "upturned nose",
+    "aquiline nose",
+    "roman nose",
+    "petite nose",
+    "snub nose",
+]
+
+LIP_SHAPES = [
+    "full lips",
+    "heart-shaped lips",
+    "bow-shaped lips",
+    "thin lips",
+    "soft pout",
+    "defined cupid's bow",
+    "plush lips",
+]
+
+FACE_DETAILS = [
+    "high cheekbones",
+    "sculpted cheekbones",
+    "soft jawline",
+    "sharp jawline",
+    "defined jawline",
+    "delicate chin",
+    "prominent dimples",
+    "rounded cheeks",
+    "hollowed cheeks",
+    "freckled cheeks",
+]
+
+# ===== Stage 3 Accents =====
+BODY_ACCENTS = [
+    "statuesque posture",
+    "graceful stance",
+    "elegant silhouette",
+    "lithe physique",
+    "poised demeanor",
+    "ballerina poise",
+    "delicate presence",
+]
+
+SKIN_ACCENTS = [
+    "radiant skin",
+    "glowing complexion",
+    "velvety skin",
+    "soft luminous skin",
+    "glossy skin sheen",
+    "silky smooth skin",
+]
+
+FACE_ACCENTS = [
+    "sparkling eyes",
+    "radiant gaze",
+    "piercing gaze",
+    "delicate features",
+    "defined cheek contour",
+    "glowing blush",
+    "refined facial structure",
+]
+
+HAIR_ACCENTS = [
+    "glossy hair",
+    "lustrous hair",
+    "silky hair",
+    "voluminous hair",
+    "flowing hair",
+    "polished hair",
+    "shiny hair",
+]
+
+SENSUAL_ACCENTS = [
+    "sultry aura",
+    "sensuous allure",
+    "smoldering gaze",
+    "tempting presence",
+]
+
+# ===== Themes =====
 THEMES = {
     "model": {
-        "body_bias": [
-            "model-like proportions",
-            "tall and graceful",
-            "balanced physique",
-        ],
-        "hair_bias": [
-            "elegant updo",
-            "waist-length",
-            "glossy",
-        ],
+        "body": {
+            "shapes": ["statuesque form", "slender frame", "toned dancer physique"],
+            "details": ["defined waistline", "long elegant legs"],
+        },
+        "skin": {
+            "tones": ["sun-kissed tan skin", "golden olive skin"],
+            "features": ["luminous glow"],
+        },
+        "hair": {
+            "lengths": ["waist-length", "mid-back length"],
+            "textures": ["sleek straight", "smooth layers"],
+            "styles": ["elegant updo", "loose flowing"],
+            "bangs": ["middle part", "no bangs"],
+            "colors": ["dark brown", "platinum blonde"],
+            "mix": ["caramel and chestnut balayage"],
+        },
+        "face": {
+            "shapes": ["oval face", "diamond-shaped face"],
+            "eyes": ["almond eyes"],
+            "nose": ["straight nose"],
+            "lips": ["full lips", "defined cupid's bow"],
+            "details": ["high cheekbones", "sculpted cheekbones", "defined jawline"],
+        },
+        "decor": {
+            "body": ["statuesque posture"],
+            "skin": ["radiant skin"],
+            "face": ["defined cheek contour"],
+            "hair": ["glossy hair"],
+        },
     },
     "kawaii": {
-        # ★ petite 系と幼さニュアンスはここに集約（ユーザ要望）
-        "body_bias": [
-            "petite yet elegant",
-            "childlike",
-            "doll-like",
-            "little girl frame",
-            "girlish",
-            "innocent look",
-            "cute childish charm",
-        ],
-        "hair_bias": [
-            "twin tails",
-            "curtain bangs",
-            "soft fringe",
-        ],
+        "body": {
+            "shapes": ["petite frame", "softly rounded figure"],
+            "details": ["delicate collarbones", "soft shoulders"],
+        },
+        "skin": {
+            "tones": ["pale rosy skin"],
+            "features": ["rosy cheeks", "soft blush", "delicate freckles"],
+        },
+        "hair": {
+            "lengths": ["shoulder-length", "collarbone-length"],
+            "textures": ["soft wavy", "gentle waves"],
+            "styles": ["twin tails", "loose braid"],
+            "bangs": ["soft fringe", "wispy bangs"],
+            "colors": ["honey blonde", "rose pink"],
+            "mix": ["peach and blonde gradient"],
+        },
+        "face": {
+            "shapes": ["round face"],
+            "eyes": ["round eyes", "upturned eyes"],
+            "nose": ["button nose", "petite nose"],
+            "lips": ["soft pout", "heart-shaped lips"],
+            "details": ["rounded cheeks", "prominent dimples", "soft jawline"],
+        },
+        "decor": {
+            "body": ["delicate presence"],
+            "skin": ["glowing blush"],
+            "face": ["sparkling eyes"],
+            "hair": ["shiny hair"],
+        },
     },
     "gothic": {
-        "body_bias": [],
-        "hair_bias": [
-            "elegant updo",
-            "deep side part",
-            "black",
-        ],
+        "body": {
+            "shapes": ["statuesque form", "slender frame"],
+            "details": ["graceful neck", "delicate collarbones"],
+        },
+        "skin": {
+            "tones": ["porcelain skin"],
+            "features": ["beauty mark below eye", "matte porcelain finish"],
+        },
+        "hair": {
+            "lengths": ["waist-length", "mid-back length"],
+            "textures": ["sleek straight"],
+            "styles": ["elegant updo", "loose flowing"],
+            "bangs": ["curtain bangs", "middle part"],
+            "colors": ["jet black", "blue-black"],
+            "mix": ["black and crimson streaks"],
+        },
+        "face": {
+            "shapes": ["oval face", "diamond-shaped face"],
+            "eyes": ["deep-set eyes", "downturned eyes"],
+            "nose": ["straight nose"],
+            "lips": ["bow-shaped lips", "full lips"],
+            "details": ["sharp jawline", "high cheekbones"],
+        },
+        "decor": {
+            "body": ["elegant silhouette"],
+            "skin": ["velvety skin"],
+            "face": ["piercing gaze"],
+            "hair": ["polished hair"],
+        },
     },
     "wasou": {
-        "body_bias": [],
-        "hair_bias": [
-            "elegant updo",
-            "soft fringe",
-            "low ponytail",
-        ],
+        "body": {
+            "shapes": ["delicate build", "graceful curves"],
+            "details": ["graceful neck", "balletic posture"],
+        },
+        "skin": {
+            "tones": ["porcelain skin", "fair neutral skin"],
+            "features": ["soft blush"],
+        },
+        "hair": {
+            "lengths": ["mid-back length"],
+            "textures": ["sleek straight", "smooth layers"],
+            "styles": ["elegant updo", "low ponytail"],
+            "bangs": ["soft fringe", "curtain bangs"],
+            "colors": ["jet black", "dark brown"],
+            "mix": ["caramel and chestnut balayage"],
+        },
+        "face": {
+            "shapes": ["oval face", "heart-shaped face"],
+            "eyes": ["almond eyes"],
+            "nose": ["straight nose"],
+            "lips": ["soft pout"],
+            "details": ["soft jawline", "delicate chin"],
+        },
+        "decor": {
+            "body": ["poised demeanor"],
+            "skin": ["silky smooth skin"],
+            "face": ["delicate features"],
+            "hair": ["polished hair"],
+        },
     },
 }
+
+# ===== Exclusive Groups =====
+EXCLUSIVE_GROUPS = {
+    "body_shape": {
+        "BODY_SHAPES": BODY_SHAPES,
+    },
+    "skin_tone": {
+        "SKIN_TONES": SKIN_DETAILS["tones"],
+    },
+    "jawline": {
+        "FACE_DETAILS": ["soft jawline", "sharp jawline", "defined jawline"],
+    },
+    "face_shape": {
+        "FACE_SHAPES": FACE_SHAPES,
+    },
+    "eye_shape": {
+        "EYE_SHAPES": EYE_SHAPES,
+    },
+    "nose_shape": {
+        "NOSE_SHAPES": NOSE_SHAPES,
+    },
+    "lip_shape": {
+        "LIP_SHAPES": LIP_SHAPES,
+    },
+    "cheek_volume": {
+        "FACE_DETAILS": ["rounded cheeks", "hollowed cheeks"],
+    },
+    "hair_length": {
+        "HAIR_LENGTHS": HAIR_LENGTHS,
+    },
+    "hair_color": {
+        "HAIR_COLORS": HAIR_COLORS,
+        "HAIR_COLOR_MIX": HAIR_COLOR_MIX,
+    },
+    "hair_part": {
+        "HAIR_BANGS_PART": HAIR_BANGS_PART,
+    },
+}
+


### PR DESCRIPTION
## Summary
- restructure appearance vocabularies to cover expanded body, skin, face, and hair descriptors with theme-aware biases and exclusivity rules
- replace the appearance tag node with a multi-stage generator that respects new vocab categories, theme bias, and face/body complexity controls
- add a stage-three enrichment pass to fill remaining length with consistent decorative descriptors while honoring mode-specific accents

## Testing
- python -m compileall .
- PYTHONPATH=/workspace python - <<'PY'
from wildcard_tagnodes.appearance_tag import AppearanceTagNode
node = AppearanceTagNode()
print(node.generate(seed=123, モード="一般", テーマ1="kawaii", 顔の造形の複雑さ=0.8, 身体的特徴の複雑さ=0.6)[0])
print(node.generate(seed=124, モード="セクシー", テーマ1="model", テーマ2="gothic", 顔の造形の複雑さ=0.95, 身体的特徴の複雑さ=0.9)[0])
PY

------
https://chatgpt.com/codex/tasks/task_e_68d79c5b2b508326822e1b4ee50d0159