### PR TITLE
Refactor tag generators to concept pack vocabularies

### DIFF
--- a/background_tag.py
+++ b/background_tag.py
@@ -1,28 +1,207 @@
-# background_tag.py
-# 仕様書に基づき、環境フィルターとテーマ連動の抽選ロジックを実装
+"""Background tag generator built on concept packs."""
 
-from .util import rng_from_seed, maybe, pick, join_clean, normalize, merge_unique
+from typing import Dict, List, Sequence
+
+from .util import rng_from_seed, maybe, pick, join_clean, normalize
 from .vocab.background_vocab import (
-    # --- 新しい構造に合わせてimport ---
-    BG_ENV_INDOOR, BG_ENV_OUTDOOR, BG_DETAILS_INDOOR, BG_DETAILS_OUTDOOR,
-    BG_ARCH_INDOOR, BG_ARCH_OUTDOOR, BG_PROPS_INDOOR, BG_PROPS_OUTDOOR,
-    BG_LIGHT, BG_TEXTURE, BG_WEATHER, BG_TIME, BG_FX,
-    THEME_PACKS, THEME_CHOICES, EXCLUSIVE_TAG_GROUPS
+    CONCEPT_PACKS,
+    GENERAL_DEFAULTS,
+    THEME_TO_PACKS,
+    THEME_CHOICES,
+    EXCLUSIVE_TAG_GROUPS,
 )
 
+FILTER_OPTIONS = ["指定しない", "屋内のみ", "屋外のみ"]
+
+
+def _resolve_theme_selection(rng, selections: Sequence[str]) -> List[str]:
+    explicit: List[str] = []
+    omakase = 0
+    for value in selections:
+        if not value or value == "none":
+            continue
+        if value == "おまかせ":
+            omakase += 1
+        else:
+            explicit.append(value)
+
+    available = [theme for theme in THEME_TO_PACKS.keys() if theme not in explicit]
+    rng.shuffle(available)
+    for _ in range(omakase):
+        if not available:
+            break
+        explicit.append(available.pop())
+
+    seen = set()
+    ordered: List[str] = []
+    for key in explicit:
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(key)
+    return ordered
+
+
+def _allowed_settings(filter_mode: str) -> List[str]:
+    if filter_mode == "屋内のみ":
+        return ["indoor", "mixed"]
+    if filter_mode == "屋外のみ":
+        return ["outdoor", "mixed"]
+    return ["indoor", "outdoor", "mixed"]
+
+
+def _candidate_pack_keys(theme_keys: Sequence[str], allowed_settings: Sequence[str]) -> List[str]:
+    candidates: List[str] = []
+    for theme in theme_keys:
+        candidates.extend(THEME_TO_PACKS.get(theme, []))
+    candidates = [key for key in candidates if CONCEPT_PACKS.get(key, {}).get("setting") in allowed_settings]
+
+    if candidates:
+        seen = set()
+        ordered: List[str] = []
+        for key in candidates:
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(key)
+        return ordered
+
+    fallback = [
+        key
+        for key, pack in CONCEPT_PACKS.items()
+        if pack.get("setting") in allowed_settings
+    ]
+    return fallback
+
+
+def _options_for_category(pack: Dict[str, object], category: str, setting: str) -> List[str]:
+    values = list(pack.get(category, []) or [])
+    if values:
+        return values
+
+    if category in {"lighting", "details", "texture", "fx"}:
+        return list(GENERAL_DEFAULTS.get(category, []))
+
+    if category == "architecture":
+        if setting == "indoor":
+            return list(GENERAL_DEFAULTS.get("architecture_indoor", []))
+        if setting == "outdoor":
+            return list(GENERAL_DEFAULTS.get("architecture_outdoor", []))
+        return list(GENERAL_DEFAULTS.get("architecture_indoor", [])) + list(GENERAL_DEFAULTS.get("architecture_outdoor", []))
+
+    if category == "props":
+        if setting == "indoor":
+            return list(GENERAL_DEFAULTS.get("props_indoor", []))
+        if setting == "outdoor":
+            return list(GENERAL_DEFAULTS.get("props_outdoor", []))
+        return list(GENERAL_DEFAULTS.get("props_indoor", [])) + list(GENERAL_DEFAULTS.get("props_outdoor", []))
+
+    return []
+
+
+def _exclusive_for(tag: str) -> List[str]:
+    exclusive: List[str] = []
+    for groups in EXCLUSIVE_TAG_GROUPS.values():
+        for group in groups:
+            if tag in group:
+                exclusive.extend(item for item in group if item != tag)
+    return exclusive
+
+
+def _build_tags(
+    rng,
+    pack_key: str,
+    確率_照明: float,
+    確率_詳細: float,
+    確率_質感: float,
+    確率_天候_季節: float,
+    確率_時間帯: float,
+    確率_効果_演出: float,
+    確率_建築_構造: float,
+    確率_小道具: float,
+) -> List[str]:
+    pack = CONCEPT_PACKS[pack_key]
+    setting = pack.get("setting", "outdoor")
+
+    selected: List[str] = []
+    exclusive_tags = set()
+
+    def add_tag(tag: str) -> None:
+        if not tag:
+            return
+        if tag in selected or tag in exclusive_tags:
+            return
+        selected.append(tag)
+        exclusive_tags.update(_exclusive_for(tag))
+
+    environment = list(pack.get("environment", []) or [])
+    if environment:
+        add_tag(pick(rng, environment))
+
+    for tag in pack.get("core", []) or []:
+        add_tag(tag)
+
+    for extra in pack.get("extras", []) or []:
+        if maybe(rng, 0.5):
+            add_tag(extra)
+
+    if pack.get("mood"):
+        add_tag(pack["mood"])  # type: ignore[index]
+
+    if pack.get("weather") and maybe(rng, 確率_天候_季節):
+        add_tag(pick(rng, list(pack["weather"])))  # type: ignore[index]
+
+    if pack.get("time") and maybe(rng, 確率_時間帯):
+        add_tag(pick(rng, list(pack["time"])))  # type: ignore[index]
+
+    if maybe(rng, 確率_照明):
+        lighting_options = _options_for_category(pack, "lighting", setting)
+        if lighting_options:
+            add_tag(pick(rng, lighting_options))
+
+    if maybe(rng, 確率_詳細):
+        detail_options = _options_for_category(pack, "details", setting)
+        if detail_options:
+            add_tag(pick(rng, detail_options))
+
+    if maybe(rng, 確率_質感):
+        texture_options = _options_for_category(pack, "texture", setting)
+        if texture_options:
+            add_tag(pick(rng, texture_options))
+
+    if maybe(rng, 確率_効果_演出):
+        fx_options = _options_for_category(pack, "fx", setting)
+        if fx_options:
+            add_tag(pick(rng, fx_options))
+
+    if maybe(rng, 確率_建築_構造):
+        arch_options = _options_for_category(pack, "architecture", setting)
+        if arch_options:
+            add_tag(pick(rng, arch_options))
+
+    if maybe(rng, 確率_小道具):
+        prop_options = _options_for_category(pack, "props", setting)
+        if prop_options:
+            add_tag(pick(rng, prop_options))
+
+    if not selected:
+        add_tag("atmospheric background")
+
+    return selected
+
+
 class BackgroundTagNode:
-    # ... (クラスの残りの部分は変更ありません) ...
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "seed": ("INT", {"default": 42, "min": 0, "max": 2**31-1}),
+                "seed": ("INT", {"default": 42, "min": 0, "max": 2**31 - 1}),
             },
             "optional": {
                 "テーマ1": (THEME_CHOICES,),
                 "テーマ2": (THEME_CHOICES,),
                 "テーマ3": (THEME_CHOICES,),
-                "環境フィルター": (["指定しない", "屋内のみ", "屋外のみ"],),
+                "環境フィルター": (FILTER_OPTIONS,),
                 "小文字化": ("BOOL", {"default": True}),
                 "確率_照明": ("FLOAT", {"default": 0.85, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "確率_詳細": ("FLOAT", {"default": 0.75, "min": 0.0, "max": 1.0, "step": 0.01}),
@@ -32,136 +211,51 @@ class BackgroundTagNode:
                 "確率_効果_演出": ("FLOAT", {"default": 0.6, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "確率_建築_構造": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "確率_小道具": ("FLOAT", {"default": 0.45, "min": 0.0, "max": 1.0, "step": 0.01}),
-            }
+            },
         }
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "generate"
     CATEGORY = "Text/Wildcards"
 
-    def _get_exclusive_tags(self, rng, selected_tags: list) -> list:
-        # この関数は変更なし
-        exclusive_tags = set()
-        for tag in selected_tags:
-            for group in EXCLUSIVE_TAG_GROUPS.values():
-                for sub_group in group:
-                    if tag in sub_group:
-                        exclusive_tags.update(t for t in sub_group if t != tag)
-        return list(exclusive_tags)
-
-    def _prepare_lists(self, theme_keys: list, filter_mode: str) -> dict:
-        """
-        環境フィルターに基づき、使用する語彙リストを動的に構築する
-        """
-        CATEGORIES = ["env", "light", "details", "texture", "weather", "time", "fx", "arch", "props"]
-        L = {cat: [] for cat in CATEGORIES}
-
-        # ベースとなる語彙を辞書として定義
-        base_vocab = {
-            "env_indoor": BG_ENV_INDOOR, "env_outdoor": BG_ENV_OUTDOOR,
-            "details_indoor": BG_DETAILS_INDOOR, "details_outdoor": BG_DETAILS_OUTDOOR,
-            "arch_indoor": BG_ARCH_INDOOR, "arch_outdoor": BG_ARCH_OUTDOOR,
-            "props_indoor": BG_PROPS_INDOOR, "props_outdoor": BG_PROPS_OUTDOOR,
-            "light": BG_LIGHT, "texture": BG_TEXTURE, "weather": BG_WEATHER,
-            "time": BG_TIME, "fx": BG_FX
-        }
-
-        # ベース語彙と選択されたテーマの語彙をリスト化
-        vocab_sources = [base_vocab] + [THEME_PACKS.get(key, {}) for key in theme_keys]
-        
-        # 各ソース（ベース語彙、テーマ）から語彙をマージ
-        for source in vocab_sources:
-            for cat in CATEGORIES:
-                is_indoor_ok = filter_mode != "屋外のみ"
-                is_outdoor_ok = filter_mode != "屋内のみ"
-
-                # 共通カテゴリ（例: light, texture）
-                if source.get(cat):
-                    L[cat] = merge_unique(L[cat], source.get(cat, []))
-                # 屋内用カテゴリ
-                if is_indoor_ok and source.get(f"{cat}_indoor"):
-                    L[cat] = merge_unique(L[cat], source.get(f"{cat}_indoor", []))
-                # 屋外用カテゴリ
-                if is_outdoor_ok and source.get(f"{cat}_outdoor"):
-                    L[cat] = merge_unique(L[cat], source.get(f"{cat}_outdoor", []))
-        return L
-
     def generate(
-        self, seed, テーマ1="none", テーマ2="none", テーマ3="none",
-        環境フィルター="指定しない", 小文字化=True,
-        確率_照明=0.85, 確率_詳細=0.75, 確率_質感=0.65, 確率_天候_季節=0.5, 
-        確率_時間帯=0.7, 確率_効果_演出=0.6, 確率_建築_構造=0.5, 確率_小道具=0.45,
+        self,
+        seed,
+        テーマ1="none",
+        テーマ2="none",
+        テーマ3="none",
+        環境フィルター="指定しない",
+        小文字化=True,
+        確率_照明=0.85,
+        確率_詳細=0.75,
+        確率_質感=0.65,
+        確率_天候_季節=0.5,
+        確率_時間帯=0.7,
+        確率_効果_演出=0.6,
+        確率_建築_構造=0.5,
+        確率_小道具=0.45,
     ):
         rng = rng_from_seed(seed)
+        theme_keys = _resolve_theme_selection(rng, [テーマ1, テーマ2, テーマ3])
+        allowed_settings = _allowed_settings(環境フィルター or "指定しない")
+        candidates = _candidate_pack_keys(theme_keys, allowed_settings)
+        if not candidates:
+            candidates = [key for key, pack in CONCEPT_PACKS.items() if pack.get("setting") in allowed_settings]
+        pack_key = pick(rng, candidates)
 
-        # --- テーマ選択ロジック（「おまかせ」対応） ---
-        selected_options = [k for k in [テーマ1, テーマ2, テーマ3] if k and k != "none"]
-        final_theme_keys = [t for t in selected_options if t != "おまかせ"]
-        omakase_count = selected_options.count("おまかせ")
-        
-        if omakase_count > 0:
-            available_for_random = [t for t in THEME_PACKS.keys() if t not in final_theme_keys]
-            rng.shuffle(available_for_random)
-            for _ in range(omakase_count):
-                if not available_for_random: break
-                final_theme_keys.append(available_for_random.pop())
-        # 重複を除去しつつ順序を維持
-        theme_keys = list(dict.fromkeys(final_theme_keys))
-        
-        # フィルターを適用して語彙リストを準備
-        L = self._prepare_lists(theme_keys, 環境フィルター)
+        tags = _build_tags(
+            rng,
+            pack_key,
+            確率_照明,
+            確率_詳細,
+            確率_質感,
+            確率_天候_季節,
+            確率_時間帯,
+            確率_効果_演出,
+            確率_建築_構造,
+            確率_小道具,
+        )
 
-        # --- 新しい抽選ロジック ---
-        # デフォルトの抽選回数
-        DEFAULT_DRAW_COUNTS = {"env": 1, "light": 1, "details": 2, "texture": 1, "weather": 1, "time": 1, "fx": 1, "arch": 1, "props": 1}
-        # テーマ選択時に抽選回数を増やすカテゴリ
-        THEME_BOOST_COUNTS = {"env": 1, "light": 1, "details": 2, "texture": 1, "arch": 2, "props": 2}
-        
-        draw_counts = DEFAULT_DRAW_COUNTS.copy()
-        if theme_keys:
-            # テーマが1つでも選択されていればブースト
-            for category, boost in THEME_BOOST_COUNTS.items():
-                draw_counts[category] = draw_counts.get(category, 0) + boost
-
-        # 各カテゴリの確率と語彙リストをマッピング
-        weighted_categories = {
-            "env": (1.0, L["env"]), "light": (確率_照明, L["light"]), "details": (確率_詳細, L["details"]),
-            "texture": (確率_質感, L["texture"]), "weather": (確率_天候_季節, L["weather"]), "time": (確率_時間帯, L["time"]),
-            "fx": (確率_効果_演出, L["fx"]), "arch": (確率_建築_構造, L["arch"]), "props": (確率_小道具, L["props"]),
-        }
-
-        parts = []
-        exclusive_tags_to_remove = set()
-        
-        # 抽選対象となるカテゴリをプール化
-        candidate_pool = [cat for cat, count in draw_counts.items() for _ in range(count)]
-        rng.shuffle(candidate_pool)
-
-        for category_name in candidate_pool:
-            probability, vocab_list = weighted_categories.get(category_name, (0, []))
-            if not vocab_list or not maybe(rng, probability):
-                continue
-            
-            # まだ選ばれておらず、排他リストにもないタグのみを抽選対象とする
-            available_tags = [t for t in vocab_list if t not in parts and t not in exclusive_tags_to_remove]
-            if not available_tags:
-                continue
-            
-            selected_tag = pick(rng, available_tags)
-            if selected_tag:
-                parts.append(selected_tag)
-                exclusive_tags_to_remove.update(self._get_exclusive_tags(rng, [selected_tag]))
-
-        # 環境タグが万一選ばれなかった場合のフォールバック
-        if not any(tag in L["env"] for tag in parts if tag) and L["env"]:
-            fallback = pick(rng, L["env"])
-            if fallback:
-                parts.insert(0, fallback)
-
-        # 最終的なプロンプトを構築
-        final_parts = [p for p in parts if p and p not in exclusive_tags_to_remove]
-        tag = join_clean(final_parts)
-        tag = normalize(tag, 小文字化)
-        
-        return (tag,)
-
+        prompt = join_clean(tags)
+        prompt = normalize(prompt, 小文字化)
+        return (prompt,)

--- a/clothing_tag.py
+++ b/clothing_tag.py
@@ -1,183 +1,301 @@
-# clothing_tag.py (v6 - 露出度選択・文字数調整強化版)
-# - UIから露出度を選択可能に
-# - 文字数上限まで積極的にタグを追加するロジックに強化
+"""Clothing tag generator using structured concept packs."""
 
 import random
-from typing import List, Optional, Dict, Set
-from .util import (
-    rng_from_seed, maybe, pick, join_clean, limit_len, normalize, merge_unique
-)
-# [修正なし] 語彙定義をインポート
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from .util import rng_from_seed, maybe, pick, join_clean, limit_len, normalize
 from .vocab.clothing_vocab import (
-    COLORS, MATERIALS, PATTERNS, STYLES, EMBELLISH,
-    TOPS, BOTTOMS, OUTERWEAR, DRESSES_SETS, LINGERIE,
-    ACCENTS_EROTIC, REVEAL_MILD, REVEAL_BOLD, REVEAL_EXPLICIT,
-    STATES,
-    THEMES, EXCLUSIVE_GROUPS
+    CONCEPT_PACKS,
+    THEME_TO_PACKS,
+    THEME_CHOICES,
+    EXPOSURE_TAGS,
+    EROTIC_ACCENTS,
+    STATE_TAGS,
+    PALETTE_DEFAULT_PROBABILITIES,
+    OPTIONAL_DETAIL_PROBABILITY,
+    STATE_DETAIL_PROBABILITY,
+    OUTERWEAR_SELECTION_PROBABILITY,
 )
 
-# ========================
-# UI日本語化のための定義
-# ========================
 MODE_MAP_JP = {"一般": "non_erotic", "セクシー": "erotic"}
-# [修正] 露出度の選択肢を更新
 EXPOSURE_MAP_JP = {"なし": "none", "マイルド": "mild", "大胆": "bold", "過激": "explicit"}
-THEME_CHOICES = ["none"] + sorted(list(THEMES.keys()))
 
-# ========================
-# 準備ヘルパ
-# ========================
-def _apply_themes(base: dict, theme_keys: List[str]) -> dict:
-    b = base.copy()
-    for k in theme_keys:
-        t = THEMES.get(k, {})
-        for vocab_key in b.keys():
-            b[vocab_key] = merge_unique(b[vocab_key], t.get(vocab_key, []))
-    return b
+PaletteProbabilities = Dict[str, float]
 
-def _get_exclusive_tags(first_tag: str) -> Set[str]:
-    exclusive_set = set()
-    for group_name, groups in EXCLUSIVE_GROUPS.items():
-        for category, tags in groups.items():
-            if first_tag in tags:
-                for other_category, other_tags in groups.items():
-                    if category != other_category:
-                        exclusive_set.update(other_tags)
-    return exclusive_set
 
-def _prepare_lists(theme_keys: List[str]) -> Dict[str, List[str]]:
-    base = {
-        "colors": COLORS, "materials": MATERIALS, "patterns": PATTERNS,
-        "styles": STYLES, "embellish": EMBELLISH, "tops": TOPS, "bottoms": BOTTOMS,
-        "outerwear": OUTERWEAR, "dresses_sets": DRESSES_SETS, "lingerie": LINGERIE,
-        "accents_erotic": ACCENTS_EROTIC, "reveal_mild": REVEAL_MILD,
-        "reveal_bold": REVEAL_BOLD, "reveal_explicit": REVEAL_EXPLICIT,
-        "states": STATES
-    }
-    if theme_keys:
-        base = _apply_themes(base, theme_keys)
-    return base
+def _resolve_theme_keys(values: Sequence[Optional[str]]) -> List[str]:
+    keys: List[str] = []
+    for value in values:
+        if value and value != "none":
+            keys.append(value)
+    # preserve order while deduplicating
+    seen: set = set()
+    ordered: List[str] = []
+    for key in keys:
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(key)
+    return ordered
 
-def _get_exposure_profile(level: str, erotic: bool, L: Dict[str, List[str]]) -> (List[str], float):
-    """露出度設定に応じたタグのプールと確率を返す"""
-    level = (level or "none").lower()
-    pool, prob = [], 0.0
-    if erotic:
-        if level == "mild":     pool, prob = L["reveal_mild"], 0.5
-        elif level == "bold":   pool, prob = L["reveal_mild"] + L["reveal_bold"], 0.75
-        elif level == "explicit": pool, prob = L["reveal_bold"] + L["reveal_explicit"], 0.9
-    else: # non-erotic
-        if level == "mild":     pool, prob = L["reveal_mild"], 0.3
-        elif level == "bold":   pool, prob = L["reveal_mild"] + L["reveal_bold"], 0.5
-    return pool, prob
 
-# ========================
-# 生成ロジック
-# ========================
-def _compose(rng: random.Random, L: Dict[str, List[str]], erotic: bool, exposure_level: str, max_len: int) -> str:
-    # --- ステージ1: 基本的な服装の組み合わせを決定 ---
-    base_tags = []
-    selected_categories = set()
-    if erotic:
-        if maybe(rng, 0.6): base_tags.append(pick(rng, L["lingerie"])); selected_categories.add("lingerie")
-        else: base_tags.extend([pick(rng, L["tops"]), pick(rng, L["bottoms"])]); selected_categories.update(["tops", "bottoms"])
-    else:
-        if maybe(rng, 0.4): base_tags.append(pick(rng, L["dresses_sets"])); selected_categories.add("dresses_sets")
-        else: base_tags.extend([pick(rng, L["tops"]), pick(rng, L["bottoms"])]); selected_categories.update(["tops", "bottoms"])
-    if "dresses_sets" in selected_categories or ("tops" in selected_categories and "bottoms" in selected_categories):
-        if maybe(rng, 0.35): base_tags.append(pick(rng, L["outerwear"])); selected_categories.add("outerwear")
+def _candidate_pack_keys(category: str, theme_keys: Sequence[str]) -> List[str]:
+    available = list(CONCEPT_PACKS.get(category, {}).keys())
+    themed: List[str] = []
+    for theme in theme_keys:
+        themed.extend(THEME_TO_PACKS.get(theme, {}).get(category, []))
+    themed = [key for key in themed if key in CONCEPT_PACKS.get(category, {})]
+    return themed or available
 
-    # --- ステージ2: 装飾的なタグを確率に基づいて追加 ---
-    all_tags = list(base_tags)
-    exclusive_tags = set().union(*[_get_exclusive_tags(tag) for tag in all_tags])
 
-    def add_tag_if_not_exclusive(category: str, probability: float):
+def _select_pack_key(rng: random.Random, category: str, theme_keys: Sequence[str], hint: Optional[str] = None) -> str:
+    available = _candidate_pack_keys(category, theme_keys)
+    if hint and hint in CONCEPT_PACKS.get(category, {}):
+        return hint
+    return pick(rng, available)
+
+
+def _flatten_choice(choice) -> List[str]:  # type: ignore[no-untyped-def]
+    if isinstance(choice, (list, tuple)):
+        return [str(item) for item in choice if item]
+    if choice:
+        return [str(choice)]
+    return []
+
+
+def _merge_probabilities(pack: Dict[str, object]) -> PaletteProbabilities:
+    merged = dict(PALETTE_DEFAULT_PROBABILITIES)
+    overrides = pack.get("palette_probabilities", {})
+    if isinstance(overrides, dict):
+        for key, value in overrides.items():
+            try:
+                merged[key] = float(value)
+            except (TypeError, ValueError):
+                continue
+    return merged
+
+
+def _apply_optional_details(rng: random.Random, pack: Dict[str, object], add_tag) -> None:  # type: ignore[no-untyped-def]
+    details = list(pack.get("optional_details", []) or [])
+    if not details:
+        return
+    rng.shuffle(details)
+    prob = pack.get("optional_detail_probability", OPTIONAL_DETAIL_PROBABILITY)
+    try:
+        probability = float(prob)
+    except (TypeError, ValueError):
+        probability = OPTIONAL_DETAIL_PROBABILITY
+    for detail in details:
         if maybe(rng, probability):
-            available_tags = [t for t in L[category] if t not in exclusive_tags]
-            if available_tags:
-                tag = pick(rng, available_tags)
-                all_tags.append(tag)
-                exclusive_tags.update(_get_exclusive_tags(tag))
-                selected_categories.add(category)
+            for tag in _flatten_choice(detail):
+                add_tag(tag)
 
-    add_tag_if_not_exclusive("colors", 0.8)
-    add_tag_if_not_exclusive("materials", 0.7)
-    add_tag_if_not_exclusive("patterns", 0.4)
-    add_tag_if_not_exclusive("styles", 0.6)
-    add_tag_if_not_exclusive("embellish", 0.5)
-    if erotic: add_tag_if_not_exclusive("accents_erotic", 0.6)
-    
-    # --- ステージ3: 露出表現の追加 ---
-    exposure_pool, exposure_prob = _get_exposure_profile(exposure_level, erotic, L)
-    if exposure_pool and maybe(rng, exposure_prob):
-        tag = pick(rng, exposure_pool)
-        if tag not in exclusive_tags:
-            all_tags.append(tag)
 
-    # --- ステージ4: 服装の状態を低確率で追加 ---
-    if maybe(rng, 0.2):
-        available_states = [s for s in L["states"] if s not in exclusive_tags]
-        if available_states: all_tags.append(pick(rng, available_states))
+def _add_state_tag(rng: random.Random, pack: Dict[str, object], add_tag) -> None:  # type: ignore[no-untyped-def]
+    states = list(pack.get("states", []) or [])
+    if not states and pack.get("use_general_states"):
+        states = list(STATE_TAGS)
+    if not states:
+        return
+    if maybe(rng, STATE_DETAIL_PROBABILITY):
+        tag = pick(rng, states)
+        add_tag(tag)
 
-    # --- [強化] ステージ5: 文字数調整 ---
-    supplementary_categories = ["styles", "embellish", "materials", "patterns", "colors"]
-    if erotic: supplementary_categories.append("accents_erotic")
-    
-    # 文字数が最大値に近づくまでタグを追加し続ける
-    while len(join_clean(all_tags)) < max_len and supplementary_categories:
-        category_to_add = rng.choice(supplementary_categories)
-        available_tags = [t for t in L[category_to_add] if t not in exclusive_tags and t not in all_tags]
-        
-        if available_tags:
-            tag = pick(rng, available_tags)
-            # 追加しても文字数を超えない場合のみ追加
-            if len(join_clean(all_tags + [tag])) <= max_len:
-                all_tags.append(tag)
-                exclusive_tags.update(_get_exclusive_tags(tag))
-            else:
-                # このタグを追加すると長すぎるので、このカテゴリは一旦試行済みとする
-                supplementary_categories.remove(category_to_add)
+
+def _expand_pack(
+    rng: random.Random,
+    category: str,
+    pack_key: str,
+    existing: List[str],
+    forbidden: Optional[set] = None,
+) -> Tuple[List[str], set, Dict[str, object]]:
+    pack = CONCEPT_PACKS[category][pack_key]
+    accumulated: List[str] = []
+    forbidden = set(forbidden or set())
+    forbidden.update(pack.get("exclusive_tags", []) or [])
+    existing_set = set(existing)
+
+    def add_tag(tag: Optional[str]) -> None:
+        if not tag:
+            return
+        cleaned = str(tag).strip()
+        if not cleaned:
+            return
+        if cleaned in forbidden:
+            return
+        if cleaned in existing_set or cleaned in accumulated:
+            return
+        accumulated.append(cleaned)
+
+    for tag in pack.get("core", []) or []:
+        add_tag(tag)
+
+    for options in (pack.get("choices", {}) or {}).values():
+        if not options:
+            continue
+        choice = pick(rng, list(options))
+        for tag in _flatten_choice(choice):
+            add_tag(tag)
+
+    palette = pack.get("palette", {}) or {}
+    palette_probs = _merge_probabilities(pack)
+    for palette_name, probability in palette_probs.items():
+        options = palette.get(palette_name, [])
+        if not options:
+            continue
+        if maybe(rng, max(0.0, min(1.0, probability))):
+            add_tag(pick(rng, list(options)))
+
+    _apply_optional_details(rng, pack, add_tag)
+    _add_state_tag(rng, pack, add_tag)
+
+    accents = list(pack.get("accent_tags", []) or [])
+    if accents:
+        for accent in accents:
+            if maybe(rng, 0.5):
+                add_tag(accent)
+
+    forbidden.update(pack.get("blocked_tags", []) or [])
+    return accumulated, forbidden, pack
+
+
+def _choose_outfit_category(rng: random.Random, erotic: bool) -> str:
+    if erotic:
+        return "dresses" if maybe(rng, 0.55) else "separates"
+    return "dresses" if maybe(rng, 0.45) else "separates"
+
+
+def _resolve_exposure_profile(
+    exposure_level: str,
+    erotic: bool,
+    pack: Dict[str, object],
+) -> Tuple[List[str], float]:
+    level = (exposure_level or "none").lower()
+    if level == "none":
+        return [], 0.0
+    if level == "explicit" and not erotic:
+        return [], 0.0
+
+    pool: List[str] = list(EXPOSURE_TAGS.get(level, []))
+    if level == "mild":
+        probability = 0.5 if erotic else 0.3
+    elif level == "bold":
+        probability = 0.75 if erotic else 0.5
+    else:  # explicit
+        probability = 0.9 if erotic else 0.0
+
+    bias = str(pack.get("exposure_bias", "")).lower()
+    if bias and bias == level:
+        probability = min(1.0, probability + 0.15)
+    elif bias and level == "bold" and bias == "explicit":
+        probability = min(1.0, probability + 0.1)
+    return pool, probability
+
+
+def _append_if_unique(tags: List[str], new_tag: Optional[str]) -> None:
+    if not new_tag:
+        return
+    cleaned = str(new_tag).strip()
+    if not cleaned:
+        return
+    if cleaned in tags:
+        return
+    tags.append(cleaned)
+
+
+def _trim_to_length(tags: List[str], max_len: int) -> List[str]:
+    if max_len <= 0:
+        return []
+    trimmed: List[str] = []
+    for tag in tags:
+        candidate = trimmed + [tag]
+        if len(join_clean(candidate)) <= max_len:
+            trimmed.append(tag)
         else:
-            # このカテゴリには追加できるタグがないのでリストから削除
-            supplementary_categories.remove(category_to_add)
+            break
+    return trimmed
 
-    return join_clean(all_tags)
 
-# ========================
-# ComfyUI Node Class
-# ========================
+def _compose(
+    rng: random.Random,
+    theme_keys: Sequence[str],
+    erotic: bool,
+    exposure_level: str,
+    max_len: int,
+) -> str:
+    selected: List[str] = []
+    forbidden: set = set()
+
+    outfit_category = _choose_outfit_category(rng, erotic)
+    base_key = _select_pack_key(rng, outfit_category, theme_keys)
+    base_tags, forbidden, base_pack = _expand_pack(rng, outfit_category, base_key, selected, forbidden)
+    selected.extend(base_tags)
+
+    outerwear_prob = OUTERWEAR_SELECTION_PROBABILITY
+    outerwear_hint = base_pack.get("outerwear_hint") if isinstance(base_pack, dict) else None
+    if outerwear_hint:
+        outerwear_prob = max(outerwear_prob, 0.45)
+    if maybe(rng, outerwear_prob):
+        outer_key = _select_pack_key(rng, "outerwear", theme_keys, hint=outerwear_hint if isinstance(outerwear_hint, str) else None)
+        outer_tags, forbidden, _ = _expand_pack(rng, "outerwear", outer_key, selected, forbidden)
+        selected.extend(outer_tags)
+
+    if erotic:
+        accent_source = list(base_pack.get("accent_tags", []) or [])
+        if not accent_source:
+            accent_source = list(EROTIC_ACCENTS)
+        if accent_source and maybe(rng, 0.65):
+            _append_if_unique(selected, pick(rng, accent_source))
+
+    pool, probability = _resolve_exposure_profile(exposure_level, erotic, base_pack)
+    if pool and maybe(rng, probability):
+        _append_if_unique(selected, pick(rng, pool))
+
+    selected = list(dict.fromkeys(selected))
+    selected = _trim_to_length(selected, max_len)
+    return join_clean(selected)
+
+
 class ClothingTagNode:
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "seed": ("INT", {"default": 42, "min": 0, "max": 2**31-1}),
+                "seed": ("INT", {"default": 42, "min": 0, "max": 2**31 - 1}),
                 "モード": (list(MODE_MAP_JP.keys()),),
-                "露出度": (list(EXPOSURE_MAP_JP.keys()), {"default": "マイルド"}), # [修正]
+                "露出度": (list(EXPOSURE_MAP_JP.keys()), {"default": "マイルド"}),
                 "最大文字数": ("INT", {"default": 150, "min": 30, "max": 4096}),
             },
             "optional": {
-                "テーマ1": (THEME_CHOICES,), "テーマ2": (THEME_CHOICES,), "テーマ3": (THEME_CHOICES,),
+                "テーマ1": (THEME_CHOICES,),
+                "テーマ2": (THEME_CHOICES,),
+                "テーマ3": (THEME_CHOICES,),
                 "小文字化": ("BOOL", {"default": True}),
-            }
+            },
         }
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "generate"
     CATEGORY = "Text/Wildcards"
 
-    def generate(self, seed, モード, 露出度, 最大文字数, テーマ1="none", テーマ2="none", テーマ3="none", 小文字化=True, **kwargs):
+    def generate(
+        self,
+        seed,
+        モード,
+        露出度,
+        最大文字数,
+        テーマ1="none",
+        テーマ2="none",
+        テーマ3="none",
+        小文字化=True,
+        **kwargs,
+    ):
         rng = rng_from_seed(seed)
         mode_en = MODE_MAP_JP.get(モード, "non_erotic")
-        exposure_en = EXPOSURE_MAP_JP.get(露出度, "none") # [修正]
-        
-        theme_keys = [k for k in [テーマ1, テーマ2, テーマ3] if k and k != "none"]
-        L = _prepare_lists(theme_keys)
-        
-        tag = _compose(rng, L, erotic=(mode_en=="erotic"), exposure_level=exposure_en, max_len=最大文字数)
-        
+        exposure_en = EXPOSURE_MAP_JP.get(露出度, "none")
+        theme_keys = _resolve_theme_keys([テーマ1, テーマ2, テーマ3])
+
+        tag = _compose(rng, theme_keys, erotic=(mode_en == "erotic"), exposure_level=exposure_en, max_len=最大文字数)
         tag = normalize(tag, 小文字化)
-        # 最終的な文字数制限は念のため残す
         tag = limit_len(tag, 最大文字数)
-        
         return (tag,)

--- a/pose_emotion_tag.py
+++ b/pose_emotion_tag.py
@@ -569,13 +569,25 @@ def _generate_tags(
     used_high_level: Set[str] = set()
 
     theme_pack = EMOTION_THEME_PACKS.get(theme) if theme != "none" else None
-    theme_profile = _theme_profile_from_pack(theme_pack)
+    raw_theme_profile = _theme_profile_from_pack(theme_pack)
+    theme_profile = dict(raw_theme_profile or {})
+
+    if theme_profile:
+        pose_conflicts = set(theme_profile.get("pose_conflicts", set()))
+        for conflict in list(pose_conflicts):
+            if conflict in pools:
+                pools.pop(conflict, None)
+        mood_conflicts = {str(label).lower() for label in theme_profile.get("mood_conflicts", set())}
+        for mood_label in mood_conflicts:
+            pool_name = f"mood_{mood_label}"
+            if pool_name in pools:
+                pools.pop(pool_name, None)
 
     # ==========================================================
     # ▼▼▼ ここからが修正・追加部分 ▼▼▼
     # ==========================================================
     # theme_profile が None の場合でも安全に扱えるよう初期化
-    if theme_profile is None:
+    if not theme_profile:
         theme_profile = {}
 
     # 「魅惑」「日常」「喜び」モードの場合、動的に涙関連のタグをブロック対象に追加

--- a/vocab/appearance_vocab.py
+++ b/vocab/appearance_vocab.py
@@ -172,8 +172,8 @@ FACE_DETAILS = [
     "high cheekbones",
     "sculpted cheekbones",
     "soft jawline",
-    "sharp jawline",
-    "defined jawline",
+    "delicately tapered jawline",
+    "softly defined jawline",
     "delicate chin",
     "prominent dimples",
     "rounded cheeks",
@@ -259,7 +259,7 @@ THEMES = {
             "eyes": ["almond eyes"],
             "nose": ["straight nose"],
             "lips": ["full lips", "defined cupid's bow"],
-            "details": ["high cheekbones", "sculpted cheekbones", "defined jawline"],
+            "details": ["high cheekbones", "sculpted cheekbones", "softly defined jawline"],
         },
         "decor": {
             "body": ["statuesque posture"],
@@ -321,7 +321,7 @@ THEMES = {
             "eyes": ["deep-set eyes", "downturned eyes"],
             "nose": ["straight nose"],
             "lips": ["bow-shaped lips", "full lips"],
-            "details": ["sharp jawline", "high cheekbones"],
+            "details": ["delicately tapered jawline", "high cheekbones"],
         },
         "decor": {
             "body": ["elegant silhouette"],
@@ -372,7 +372,7 @@ EXCLUSIVE_GROUPS = {
         "SKIN_TONES": SKIN_DETAILS["tones"],
     },
     "jawline": {
-        "FACE_DETAILS": ["soft jawline", "sharp jawline", "defined jawline"],
+        "FACE_DETAILS": ["soft jawline", "delicately tapered jawline", "softly defined jawline"],
     },
     "face_shape": {
         "FACE_SHAPES": FACE_SHAPES,

--- a/vocab/background_vocab.py
+++ b/vocab/background_vocab.py
@@ -1,541 +1,428 @@
-# background_vocab.py
-# 語彙を大幅に拡充し、テーマパックを屋内/屋外の構造に完全対応させた完成版
-# New themes added: solapunk_art_nouveau, tropical_resort, cozy_academia
+"""Background concept pack vocabulary."""
 
-# ========================
-# デフォルト語彙（拡充・再分類済み）
-# ========================
+from typing import Dict, List
 
-# --- 環境 (ENV) ---
-BG_ENV_INDOOR = [
-    "sun-drenched bedroom interior", "cozy reading nook", "boudoir set with silk drapery", "luxurious hotel suite",
-    "vanity table scene with scattered cosmetics", "minimalist photo studio", "industrial loft apartment with exposed brick",
-    "traditional tatami room", "ryokan suite with a garden view", "rustic farmhouse kitchen", "antique study filled with books",
-    "glass greenhouse interior", "sunroom with lush plants", "abandoned factory floor", "cozy cafe with warm lighting",
-    "bustling restaurant kitchen", "dusty old bookstore aisle", "minimalist art gallery interior", "grand museum hall",
-    "empty swimming pool", "corporate office cubicle", "empty theater stage with a single spotlight", "backstage dressing room",
-    "vintage movie theater", "retro record shop interior", "high-rise lounge bar with a city view", "glass elevator lobby",
-    "subway concourse interior", "dimly lit bus terminal", "gothic cathedral nave", "baroque ballroom", "secret hidden library",
-    "ancient temple interior", "steamy locker room", "artist's studio with paint splatters", "green-screen studio", "dimly lit basement workshop",
-    "opulent opera house", "grand library with skylight", "wizard's tower study", "alchemist's laboratory", "throne room of a castle",
-    # New additions
-    "spaceship cockpit with a view of stars", "gleaming biodome interior", "stellar observatory dome", "engine room with glowing conduits",
-    "hydroponics bay with alien plants", "sunlit conservatory", "spacious artist's loft", "abandoned subway station",
-    "bustling indoor marketplace", "grand hotel lobby", "underground cavern temple", "scribe's scriptorium with scrolls",
-    "ornate palace hall"
-]
-BG_ENV_OUTDOOR = [
-    "rooftop garden overlooking the city", "quiet back alley with cobblestones", "lantern-lit lane at dusk",
-    "neon-soaked street at night", "seaside boardwalk at sunrise", "deep forest clearing with soft moss", "serene bamboo grove",
-    "wildflower meadow at golden hour", "vast desert overlook at twilight", "rain-soaked boulevard", "snowy sidewalk",
-    "serene park gazebo", "lush botanical garden path", "mystical waterfall basin", "tranquil riverbank",
-    "old lakeside pier at dawn", "picturesque canal promenade", "rustic country road", "vineyard terraces",
-    "meadow with hay bales at sunset", "bustling urban street corner", "pedestrian overpass at night", "busy train station platform",
-    "suburban backyard with a swing set", "childhood playground at dusk", "abandoned construction site", "car junkyard", "rural gas station",
-    "highway rest stop at midnight", "city skyline at dusk", "suburban street at night", "quiet beach at sunrise",
-    "mystical forest with ancient trees", "snowy mountain pass", "frozen lake", "autumn forest with vibrant colors",
-    "misty graveyard at midnight", "enchanted forest with glowing mushrooms", "floating islands in the sky", "castle courtyard",
-    # New additions
-    "majestic canyon overlook", "rim of a volcanic crater", "active geyser field", "shimmering salt flats",
-    "ancient glacier field", "glowing crystal forest", "alien jungle with exotic flora", "derelict spaceship graveyard in a desert",
-    "bustling city plaza with fountains", "picturesque canal city", "terraced rice paddies on a mountainside",
-    "ancient amphitheater ruins", "sprawling vineyard on a hillside", "a lone lighthouse on a cliff"
-]
-
-# --- ディテール (DETAILS) ---
-# --- ディテール (生成指示カテゴリ) ---
-BG_DETAILS_INDOOR = [
-    "a delicate detail **highlighted by a soft light**",
-    "the **interplay of light and shadow** creating intricate patterns on surfaces",
-    "a subtle imperfection that adds a touch of **realism and charm**",
-    "**reflections on a polished surface** that add depth and complexity",
-    "elegant signs of **aging and history**, like patina or worn velvet",
-    "subtle hints of the atmosphere, like **rising steam or condensation**",
-    "a single, **eye-catching detail** that serves as a focal point",
-    "a subtle imperfection that adds realism"
-]
-BG_DETAILS_OUTDOOR = [
-    "the way **sunlight filters through leaves or clouds**, creating dappled light",
-    "the **texture of the ground** revealed by raking light (e.g., wet cobblestones, dry cracked earth)",
-    "a small detail that hints at the history of this location",
-    "subtle movements in nature, like **wind rustling through grass** or ripples on water",
-    "man-made objects slowly being reclaimed by nature"
-]
-
-# --- 建築/構造 (ARCH) ---
-BG_ARCH_INDOOR = [
-    "arched doorway", "bay window with a cushioned seat", "spiral staircase", "exposed brick wall", "industrial pipes overhead",
-    "open beam ceiling", "paper sliding doors (shoji)", "baroque columns", "stained glass window", "vaulted ceiling",
-    "hidden passageway behind a bookshelf", "ornate fireplace", "library stacks stretching to the ceiling", "grand staircase",
-    "sunken lounge area", "two-story atrium", "mezzanine level overlooking a hall", "grand gallery with portraits", "indoor balcony",
-    "captain's quarters on a starship", "holographic control room", "observation deck with reinforced glass"
-]
-BG_ARCH_OUTDOOR = [
-    "stone torii gate", "retro phone booth", "vintage signboard", "ramen shop counter open to the street", "concrete overpass",
-    "rusted fire escape", "ornate iron fence", "abandoned train car on overgrown tracks", "gothic spires against the sky",
-    "flying buttresses of a cathedral", "modern glass facade reflecting the sky", "sloping tiled roof (kawara)", "wrought-iron balcony",
-    "ancient stone ruins", "ruined castle walls", "suspension bridge cables at night", "monumental arch", "old stone well", "wooden windmill",
-    "drawbridge of a castle", "ornate bell tower", "ancient roman aqueduct", "colonnade pathway", "pergola covered in vines",
-    "spaceship landing pad", "base of a space elevator", "floating platforms connected by bridges"
-]
-
-# --- 小道具 (PROPS) ---
-BG_PROPS_INDOOR = [
-    "an **aesthetically pleasing arrangement** of related items",
-    "a **deliberate, minimalist placement** of a few beautiful objects",
-    "an organic, **lived-in clutter** that feels natural and inviting",
-    "functional items that also possess an **artistic or elegant design**",
-    "a single, significant object that is the **center of the scene's narrative**",
-    "objects that **harmoniously blend** with the surrounding environment's color and style",
-    "props that **cast interesting shadows** or reflect the ambient light"
-]
-BG_PROPS_OUTDOOR = [
-    "items that seem **intentionally placed for a specific purpose** or ritual",
-    "a comfortable setup that **invites someone to rest** (e.g., a bench with a forgotten book, a picnic blanket)",
-    "remnants of a celebration or gathering, suggesting a **recent happy memory**",
-    "objects that create a **stark but beautiful contrast** with the natural environment",
-    "a trail of small items that **guides the eye** through the scene",
-    "seasonal decorations that **enhance the feeling of the time of year**"
-]
-
-# --- 共通カテゴリ (分割不要) ---
-BG_LIGHT = [
-    "soft warm lighting", "low-key dramatic lighting", "rim lighting", "backlit glow", "window daylight filtering through dust",
-    "colorful neon accent lights", "flickering candlelight ambience", "spotlit highlight", "golden-hour light",
-    "ethereal moonlit ambience", "cinematic film noir lighting", "harsh stage spotlight", "colored gel lighting",
-    "overhead fluorescent light", "glowing monitor light on a face", "soft fireplace glow", "powerful searchlight beams",
-    "strobe light effect", "blurry headlights in the rain", "streetlamp pools of light", "paper lantern glow",
-    "sunlight filtering through leaves (komorebi)", "dusty light rays", "subtle glow from a device screen", "volumetric light rays"
-]
-BG_TEXTURE = [
-    "silky textures", "velvet textures", "sheer fabrics", "glossy reflections", "matte backdrop", "brushed metal",
-    "weathered wood", "polished marble", "frosted glass", "grainy film texture", "cracked concrete", "rusted steel",
-    "wet asphalt gloss", "smooth stone wall", "rough brick texture", "fluffy cotton", "burlap sack", "silk and satin",
-    "distressed leather", "reflective chrome", "smooth plastic surface", "mossy cobblestone", "peeling paint",
-    "iridescent shimmer", "smooth silk folds", "woven wicker", "bamboo texture", "tarnished brass", "holographic surface"
-]
-BG_WEATHER = [
-    # Bright & Positive Weather
-    "perfect sunny day", "clear sky", "bright daylight", "crisp morning air", "warm gentle breeze", "beautiful afterglow",
-    "sunbeam breaking through clouds", "rainbow after a sun shower", "pollen breeze", "blinding sunlight", "hazy summer day",
-    # Rain & Wet
-    "light drizzle", "heavy rain", "sun shower", "wet pavement shine", "raindrops on window",
-    # Snow
-    "gentle snowfall", "heavy blizzard", "diamond dust (ice crystals in air)",
-    # Mist & Fog
-    "misty air", "thick morning fog", "bioluminescent fog",
-    # Clouds & Sky
-    "overcast sky", "dramatic storm clouds", "fluffy white clouds", "lenticular clouds", "vibrant sunset clouds",
-    # Storm
-    "thunderstorm with lightning", "calm before a storm",
-    # Fantastic & Special
-    "meteor shower", "aurora borealis", "solar eclipse", "floating particles of light", "comet in the night sky",
-    # General Conditions
-    "chilly winter air", "calm ocean with gentle waves"
-]
-BG_TIME = [
-    "sunrise", "morning light", "high noon light", "golden hour", "twilight", "blue hour", "deep midnight",
-    "pre-dawn darkness", "late evening", "afternoon sun"
-]
-BG_FX = [
-    "volumetric light rays", "light leaks", "lens flare", "dynamic neon glow", "cinematic haze", "soft vignette",
-    "prismatic diffraction", "reflections on wet ground", "steam rising from a manhole", "rain droplets on glass",
-    "snow flurry in the air", "fire sparks and embers", "magical particles floating", "glowing motes of dust",
-    "lens distortion", "glitching effect on a screen", "smoke trails", "long exposure light trails", "chromatic aberration",
-    "dynamic shadows", "light shafts", "beautiful bokeh background", "foggy haze"
-]
-
-# ========================
-# テーマパック (構造更新・拡充済み)
-# ========================
-# background_vocab.py に記述する THEME_PACKS の全体を置き換えてください
-
-THEME_PACKS = {
-    "cyberpunk_futuristic": {
-        "env_indoor": ["sleek starship interior", "space station viewport", "holographic command room", "cybernetic clinic", "hi-tech laboratory", "glowing data center", "grimy noodle bar", "back-alley cybernetics clinic"],
-        "env_outdoor": ["futuristic metropolis", "cyberpunk street scene", "floating city in the clouds", "maglev transit hub", "off-world colony", "dystopian cityscape", "acid rain-slicked streets", "mega-corporation ziggurat"],
-        "texture": ["brushed alloy", "carbon fiber", "glass panels", "iridescent materials", "chrome plating", "glowing circuit patterns", "wet asphalt"],
-        "light": ["neon rim light", "holographic glow", "fluorescent strip light", "lens flare from flying vehicle"],
-        "arch_indoor": ["transparent skybridge", "sleek modular buildings"],
-        "arch_outdoor": ["luminescent pylons", "data spine towers", "floating platforms", "endless skyscrapers"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "the **constant, restless flow of holographic data** streams",
-            "**glitching and distorted light** from aging electronics",
-            "the **sleek, reflective surfaces** of advanced cybernetics",
-            "a **network of cables and conduits** integrated into the architecture"
-        ],
-        "details_outdoor": [
-            "the **atmospheric haze** catching and diffusing the city's countless lights",
-            "**reflections of the neon-drenched city** in puddles of acid rain",
-            "the **overwhelming sense of scale** from towering mega-structures",
-            "**digital graffiti and advertisements** projected onto building facades"
-        ],
-        "props_indoor": [
-            "**utilitarian, function-over-form technology** common on the streets",
-            "**discarded or broken cybernetic parts** hinting at a recent conflict",
-            "**sleek, corporate-branded technology** that looks pristine and intimidating",
-            "a **makeshift setup** of cobbled-together electronics"
-        ],
-        "props_outdoor": [
-            "**automated drones** performing mundane tasks like delivery or surveillance",
-            "**objects that suggest a stark divide** between the rich and the poor",
-            "**public terminals and interfaces** integrated into the urban landscape",
-            "**heavily armored vehicles** that signify a corporate or state presence"
-        ],
-    },
-    "school": {
-        "env_indoor": ["classroom with wooden desks", "sunlit library aisles", "science lab benches", "school gymnasium", "school cafeteria", "empty hallway with lockers", "music room", "art room"],
-        "env_outdoor": ["school courtyard under cherry blossoms", "track field bleachers", "school gate", "school rooftop", "basketball court at sunset", "swimming pool for lessons"],
-        "texture": ["scuffed linoleum", "polished gym floor", "worn wooden desks", "graffiti on locker doors"],
-        "light": ["fluorescent classroom lighting", "sunlight through large windows", "late afternoon sun on the field"],
-        "arch_indoor": ["corridor with lockers", "stairwell with afternoon light"],
-        "arch_outdoor": ["brick facade", "school bell tower", "chain-link fence around sports field"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "**sunlight streaming through large windows**, illuminating floating dust motes",
-            "**personal touches and doodles** left behind on desks and lockers",
-            "the **organized chaos** of a classroom in active use",
-            "a sense of **quiet nostalgia and memories** lingering in the empty spaces"
-        ],
-        "details_outdoor": [
-            "the **play of shadows** on the ground in the late afternoon",
-            "**evidence of the changing seasons** on the school grounds",
-            "the **faded lines and worn surfaces** of a well-used sports court",
-            "a **gentle breeze** carrying the sounds of distant activity"
-        ],
-        "props_indoor": [
-            "**materials for learning and creativity**, arranged on desks",
-            "**evidence of extracurricular activities** and student passions",
-            "**items that show the passage of a long school day**",
-            "**trophies and awards** that speak to the school's history and pride"
-        ],
-        "props_outdoor": [
-            "**sports equipment** left out as if a game just ended",
-            "**items forgotten by students**, telling a small story",
-            "**bicycles neatly parked**, suggesting the daily commute of students",
-            "**seasonal decorations** for a school event or festival"
-        ],
-    },
-    "fantasy": {
-        "env_indoor": ["wizard tower study", "crystal conservatory", "ancient library", "dragon's hoard cavern", "throne room of a castle", "alchemist's laboratory", "enchanted forest cottage", "elven hall", "dwarven forge"],
-        "env_outdoor": ["floating islands in sky", "enchanted forest with glowing mushrooms", "crystal cavern", "moonlit meadow", "fairy ring in a forest", "ancient ruins on a misty hill", "dragon's peak with lava flow"],
-        "texture": ["iridescent crystal", "mossy stone", "ancient runes on rock", "dragon scales", "mithril silver"],
-        "light": ["ethereal moonlight", "bioluminescent glow", "arcane glow from a spell", "light from glowing crystals"],
-        "arch_indoor": ["ancient stone archways", "spires of a wizard's tower", "crystal formations"],
-        "arch_outdoor": ["ruined castle walls", "elven tree-houses", "bridge made of light"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "an **ambient, magical glow** emanating from an unseen source",
-            "the air **shimmering with raw magical energy**",
-            "**ancient, intricate carvings** that tell a forgotten story",
-            "**fantastical flora** integrated into the architecture"
-        ],
-        "details_outdoor": [
-            "**particles of light or magic** drifting gently in the air",
-            "the **colossal scale of ancient ruins** or natural formations",
-            "an **otherworldly quality to the natural light**",
-            "**impossible geography** that defies the laws of physics"
-        ],
-        "props_indoor": [
-            "**artifacts of immense power or ancient knowledge**",
-            "**ingredients and tools for alchemy or spellcrafting**",
-            "**objects of regal or divine significance**",
-            "a **legendary weapon or item**, presented with reverence"
-        ],
-        "props_outdoor": [
-            "**objects that serve as a source of immense magical power**",
-            "**remains of a great battle** from a bygone era",
-            "**offerings left for ancient gods or spirits**",
-            "**a path marked by mystical stones or lights**"
-        ],
-    },
-    "gothic_horror": {
-        "env_indoor": ["haunted mansion hallway", "dusty gothic library", "crypt interior", "abandoned chapel", "laboratory of a mad scientist"],
-        "env_outdoor": ["misty graveyard at midnight", "crumbling abbey ruins", "dark forest with twisted trees", "lonely cliffside castle"],
-        "texture": ["aged stone", "tattered velvet", "cold iron bars", "rotting wood", "dusty surfaces"],
-        "light": ["dim candlelight", "pale moonlight filtering through grimy windows", "lightning flashes", "single oil lamp"],
-        "arch_indoor": ["pointed arches", "stone spiral staircase", "gargoyles looking down"],
-        "arch_outdoor": ["flying buttresses", "cemetery gates", "crypt entrance"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "**deep, imposing shadows** that seem to hide something",
-            "a **thick layer of dust** covering everything, disturbed in one spot",
-            "the feeling of being **watched by portraits** on the wall",
-            "a **chilling draft** from an unseen source"
-        ],
-        "details_outdoor": [
-            "**twisted, skeletal trees** silhouetted against a pale moon",
-            "a **dense, rolling fog** that obscures the ground",
-            "the **ominous shapes of crumbling ruins** in the darkness",
-            "an **unnatural silence** in the air"
-        ],
-        "props_indoor": [
-            "**objects suggesting a dark and disturbing history**",
-            "**items that have been left in a hurry**, as if fleeing",
-            "**scientific or occult instruments** for a sinister purpose",
-            "a **single object that is unnervingly out of place**"
-        ],
-        "props_outdoor": [
-            "**weathered tombstones, some overturned or broken**",
-            "**tools for digging**, left abandoned",
-            "a **solitary, flickering lantern** suggesting a lone presence",
-            "**personal belongings lost or discarded** in the mud"
-        ],
-    },
-    "solapunk_art_nouveau": {
-        "env_indoor": ["sun-drenched atrium with lush greenery", "bio-luminescent library", "hydroponic garden room", "ornate conservatory with brass mechanics", "artist's workshop with stained-glass windows", "elegant tea room with floral motifs"],
-        "env_outdoor": ["city with verdant skyscrapers", "floating botanical islands", "solar-sail shipyard at dawn", "market street with clockwork vendors", "sweeping organic-shaped bridges over a canal", "community rooftop garden"],
-        "light": ["warm golden sunlight", "soft bioluminescent glow", "light filtering through stained glass", "dappled light through leaves"],
-        "texture": ["polished wood", "tarnished brass", "woven fabrics", "smooth ivory", "embossed leather", "mother-of-pearl inlays"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "**intricate, flowing lines** inspired by nature in the architecture",
-            "the **harmonious integration of plant life** and living space",
-            "the **gentle, rhythmic movement** of clockwork mechanisms",
-            "**sunlight creating beautiful patterns** as it passes through stained glass"
-        ],
-        "details_outdoor": [
-            "the **elegant fusion of technology and nature**",
-            "a **sense of community and sustainable living**",
-            "the **play of light on brass and copper** architectural details",
-            "**graceful, flowing forms** in bridges, buildings, and vehicles"
-        ],
-        "props_indoor": [
-            "**beautifully crafted objects that are both artistic and functional**",
-            "**items related to botany, art, or astronomy**",
-            "**elegant furniture with organic, curved lines**",
-            "**automatons designed with artistic flair**, performing helpful tasks"
-        ],
-        "props_outdoor": [
-            "**ornate, beautifully designed public transportation**, like airships or trams",
-            "**community gardens and shared spaces** for public enjoyment",
-            "**kinetic sculptures powered by wind or solar energy**",
-            "**market stalls selling handcrafted goods and organic produce**"
-        ],
-    },
-    "tropical_resort": {
-        "env_indoor": ["luxurious hotel suite with ocean view", "overwater bungalow interior", "spa room with orchid decorations", "thatched-roof restaurant", "aquarium lobby", "breezy cabana interior"],
-        "env_outdoor": ["white sand beach with turquoise water", "infinity pool overlooking the ocean", "palm tree-lined boardwalk", "secluded waterfall lagoon", "bustling beachside bar", "coral reef visible from a glass-bottom boat"],
-        "light": ["bright tropical sunlight", "golden sunset over the water", "soft lantern light at night", "light reflecting off the water's surface"],
-        "texture": ["fine white sand", "rough palm tree bark", "smooth wet stones", "woven rattan", "crisp linen sheets"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "a **gentle sea breeze** causing sheer curtains to billow",
-            "the **clean, refreshing scent** of tropical flowers and salt air",
-            "the **seamless transition** between indoor and outdoor space",
-            "**details made from natural materials** like wood, stone, and shell"
-        ],
-        "details_outdoor": [
-            "the **crystal-clear quality of the turquoise water**",
-            "the **soft, warm texture of the white sand**",
-            "the **sound of gentle waves** lapping the shore",
-            "the **vibrant colors of tropical flora** against the blue sky"
-        ],
-        "props_indoor": [
-            "**items that invite relaxation and comfort**",
-            "**luxurious amenities** for a perfect vacation",
-            "a **refreshing tropical drink or fresh fruit**, beautifully presented",
-            "**furniture made from light, natural materials** like wicker or bamboo"
-        ],
-        "props_outdoor": [
-            "**equipment for enjoying the water**, like surfboards or kayaks",
-            "a **perfectly placed spot to relax and enjoy the view**",
-            "**tiki torches or lanterns that create a romantic mood** at dusk",
-            "**objects that suggest leisure and carefree living**"
-        ],
-    },
-    "cozy_academia": {
-        "env_indoor": ["grand library with endless bookshelves", "cozy professor's study with a fireplace", "potions classroom with bubbling cauldrons", "observatory with a large telescope", "natural history museum hall at night", "common room with plush armchairs"],
-        "env_outdoor": ["university courtyard with ivy-covered walls", "ancient campus grounds in autumn", "botanical greenhouse for magical plants", "cobblestone alley leading to a hidden bookshop", "college quad at twilight"],
-        "light": ["warm light from a fireplace", "sunlight filtering through large arched windows", "soft glow from a desk lamp", "mysterious glow from a magical object"],
-        "texture": ["aged paper", "dusty book covers", "worn leather armchairs", "dark polished wood", "cold stone floors", "tweed fabric"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "the **smell of old books, woodsmoke, and brewing tea**",
-            "the **comforting silence of a library**, broken only by turning pages",
-            "**motes of dust dancing in a sunbeam** filtering through a tall window",
-            "a **sense of deep history and accumulated knowledge**"
-        ],
-        "details_outdoor": [
-            "the **crisp feeling of autumn air**",
-            "**ivy clinging to ancient stone walls**",
-            "the **sound of distant bells or a choir**",
-            "the **warm, inviting glow** from windows at twilight"
-        ],
-        "props_indoor": [
-            "**piles and shelves of books**, suggesting a love of reading and research",
-            "**objects related to scholarly pursuits** like astronomy, history, or botany",
-            "a **comfortable place to sit and read** for hours",
-            "**items that suggest a touch of magic or mystery** hidden within the academic setting"
-        ],
-        "props_outdoor": [
-            "**architectural features that inspire a sense of wonder and history**",
-            "a **quiet, secluded bench** perfect for contemplation",
-            "**items that hint at the traditions and ceremonies** of the institution",
-            "**seasonal elements**, like fallen leaves or a light dusting of snow"
-        ],
-    },
-    "wafu_serenity_nature": {
-        "env_indoor": ["shoji screen room with soft light", "traditional tea room (chashitsu)", "ryokan room with a cypress bath", "samurai residence study room", "veranda with a moon-viewing platform"],
-        "env_outdoor": ["dry landscape garden (karesansui)", "bamboo grove path with sunlight filtering through", "stone steps lined with cedar trees", "Japanese garden with a koi pond", "castle town at dusk"],
-        "light": ["soft light through shoji paper screens", "sunlight filtering through trees (komorebi)", "warm glow of paper lanterns"],
-        "texture": ["tatami mat texture", "plastered wall", "polished wooden floor", "washi paper texture"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "the **play of light and shadow** through a lattice screen",
-            "a **perfectly framed view of the garden** from inside",
-            "an atmosphere of **tranquility, simplicity, and wabi-sabi**",
-            "the **scent of tatami, hinoki wood, and green tea**"
-        ],
-        "details_outdoor": [
-            "the **sound of a shishi-odoshi** (deer-scarer) or a gentle stream",
-            "the **feeling of moss underfoot** on ancient stones",
-            "the **dance of light and shadow** in a bamboo grove",
-            "a **sense of deep peace and harmony with nature**"
-        ],
-        "props_indoor": [
-            "a **single, beautiful object, perfectly placed** in an alcove (tokonoma)",
-            "**items for a traditional art or ceremony**, like tea ceremony or calligraphy",
-            "**minimalist furniture** that emphasizes the beauty of the space",
-            "**objects that reflect a deep appreciation for nature and craftsmanship**"
-        ],
-        "props_outdoor": [
-            "**stones and sand raked into patterns** that evoke water and mountains",
-            "**elements designed to blend seamlessly with the natural landscape**",
-            "a **place for quiet contemplation and meditation**",
-            "**objects that change beautifully with the seasons**"
-        ],
-    },
-    "space_opera": {
-        "env_indoor": ["spaceship bridge with a panoramic viewport", "gleaming white space station corridor", "emperor's throne room on a capital planet", "bustling alien cantina", "holographic library"],
-        "env_outdoor": ["alien futuristic city skyline", "spaceport with departing and arriving ships", "lunar surface with twin suns", "palace's zero-gravity garden", "crystalline asteroid belt"],
-        "light": ["harsh light from a star", "blueish glow from engines", "colorful light from a nebula"],
-        "texture": ["polished metal armor", "luminous glass panels", "smooth nano-materials"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "a **panoramic view of stars, planets, or nebulae** through a large window",
-            "the **low, constant hum of a starship's engine** or life support",
-            "the **clean, sterile look of advanced technology**",
-            "**holographic displays and interfaces** integrated everywhere"
-        ],
-        "details_outdoor": [
-            "the **breathtaking scale of alien megastructures** or celestial phenomena",
-            "the **sight of multiple moons or suns** in the sky",
-            "the **vibrant, chaotic energy** of a multicultural spaceport",
-            "an **awe-inspiring view of a fleet of starships**"
-        ],
-        "props_indoor": [
-            "**advanced technology for command, control, and communication**",
-            "**items that show the diversity of alien species** present",
-            "**personal belongings that hint at a life spent traveling the stars**",
-            "**symbols of power and authority** within a galactic empire or federation"
-        ],
-        "props_outdoor": [
-            "**a variety of starships, from sleek fighters to massive cruisers**",
-            "**technology for terraforming or resource extraction on an alien world**",
-            "**monuments or statues commemorating a great historical event**",
-            "**defensive installations**, like energy shields or weapon platforms"
-        ],
-    },
-    "desert_oasis_arabian_nights": {
-        "env_indoor": ["palace hall adorned with mosaic tiles", "throne room with fragrant incense smoke", "library with countless scrolls", "interior of a luxurious tent with rich textiles", "alchemist's hidden workshop"],
-        "env_outdoor": ["vast sun-drenched sand dunes", "vibrant marketplace (souk) with colorful goods", "palace courtyard with a fountain", "secret oasis with a waterfall", "ancient ruins half-buried in sand"],
-        "light": ["strong desert sunlight", "deep blue night sky full of stars", "flickering light of lanterns"],
-        "texture": ["fine sand", "glossy glazed tiles", "densely woven carpets", "hammered metalwork"],
-        # ★★★ details/props を抽象的な指示に更新 ★★★
-        "details_indoor": [
-            "**intricate geometric patterns** (zellige) that create a mesmerizing effect",
-            "**cool air and the gentle sound of water**, a stark contrast to the outside heat",
-            "the **rich aroma of spices, incense, and perfumes**",
-            "**ornate archways and latticework** that create beautiful, complex shadows"
-        ],
-        "details_outdoor": [
-            "the **shimmering heat haze** rising from the endless sand dunes",
-            "the **vibrant, chaotic energy of a bustling marketplace** (souk)",
-            "the **brilliant, dazzling display of stars** in a clear desert night sky",
-            "a **sense of ancient history and forgotten magic** among the ruins"
-        ],
-        "props_indoor": [
-            "**luxurious textiles, like silk cushions and elaborate carpets**, for comfort and beauty",
-            "**items that suggest wealth, trade, and a long history of storytelling**",
-            "**objects related to magic, alchemy, or astronomy**",
-            "a **source of cool, clean water**, the most valuable treasure in the desert"
-        ],
-        "props_outdoor": [
-            "**elements that provide shade and relief from the intense sun**",
-            "**goods from all corners of the world**, hinting at a crossroads of trade",
-            "**evidence of a hidden, magical world** just beneath the surface",
-            "**items needed for a long journey across the vast desert**"
-        ],
-    }
+GENERAL_DEFAULTS: Dict[str, List[str]] = {
+    "lighting": [
+        "soft warm lighting",
+        "golden-hour light",
+        "ethereal moonlit ambience",
+        "colorful neon accent lights",
+        "rim lighting",
+        "glowing lantern light",
+    ],
+    "details": [
+        "floating dust motes in the air",
+        "handcrafted details that hint at a lived-in story",
+        "light catching on delicate surfaces",
+        "the interplay of light and shadow revealing depth",
+        "subtle motion from drifting leaves or fabric",
+    ],
+    "texture": [
+        "weathered wood grain",
+        "polished stone floor",
+        "wet cobblestone gloss",
+        "smooth marble",
+        "bamboo texture",
+        "holographic reflections",
+    ],
+    "fx": [
+        "soft cinematic haze",
+        "volumetric light rays",
+        "light leaks",
+        "rain droplets on glass",
+        "glowing motes of dust",
+        "long exposure light trails",
+    ],
+    "architecture_indoor": [
+        "arched doorway",
+        "vaulted ceiling",
+        "spiral staircase",
+        "grand library shelves",
+        "paper sliding doors",
+    ],
+    "architecture_outdoor": [
+        "stone torii gate",
+        "ornate wrought-iron balcony",
+        "gently curving boardwalk",
+        "ancient stone ruins",
+        "sleek skybridge",
+    ],
+    "props_indoor": [
+        "arranged vintage books",
+        "decorative tea set",
+        "stacked handwritten letters",
+        "scatter of art supplies",
+        "soft cushions arranged for comfort",
+    ],
+    "props_outdoor": [
+        "lanterns lining the path",
+        "flower petals on the breeze",
+        "market stalls with textiles",
+        "ritual offering table",
+        "picnic blanket inviting rest",
+    ],
 }
 
-# UIで使うテーマの選択肢リスト
-THEME_CHOICES = ["none", "おまかせ"] + sorted(list(THEME_PACKS.keys()))
+CONCEPT_PACKS: Dict[str, Dict[str, object]] = {
+    "rainy_neon_alley": {
+        "label": "雨に濡れた夜の路地裏",
+        "setting": "outdoor",
+        "themes": ["cyberpunk_futuristic"],
+        "environment": ["rain-soaked neon alley", "narrow street shimmering with reflected signs"],
+        "core": ["slick reflective pavement", "towering signage overhead"],
+        "lighting": ["neon signage glow", "holographic glow from billboards"],
+        "weather": ["heavy rain", "wet pavement shine"],
+        "time": ["midnight", "blue hour"],
+        "details": ["rain cascading from awnings", "puddles mirroring electric colors"],
+        "texture": ["wet asphalt gloss", "dripping chrome surfaces"],
+        "props": ["flickering holographic billboard", "hanging paper lanterns"],
+        "architecture": ["mega-corporation tower silhouettes", "crowded alleyway signage"],
+        "fx": ["rain droplets on glass", "long exposure light trails"],
+    },
+    "holographic_concourse": {
+        "label": "サイバーパンク都市の交差点",
+        "setting": "outdoor",
+        "themes": ["cyberpunk_futuristic", "space_opera"],
+        "environment": ["futuristic metropolis plaza", "elevated concourse with maglev lines"],
+        "core": ["streaming holographic advertisements", "dense crowd silhouettes"],
+        "lighting": ["pulsing neon strips", "ambient holographic bloom"],
+        "weather": ["misty air"],
+        "time": ["twilight", "night"],
+        "details": ["digital rain of data", "reflections in mirrored architecture"],
+        "texture": ["polished alloy floor", "translucent glass panels"],
+        "props": ["drifting service drones", "augmented reality kiosks"],
+        "architecture": ["floating platforms", "luminescent pylons"],
+        "fx": ["glitching light fragments", "lens flare from flying vehicles"],
+    },
+    "cozy_reading_nook": {
+        "label": "木漏れ日が差す静かな読書スペース",
+        "setting": "indoor",
+        "themes": ["cozy_academia", "school"],
+        "environment": ["sun-drenched reading nook", "bay window lined with cushions"],
+        "core": ["overflowing bookshelves", "stacked handwritten notes"],
+        "lighting": ["soft warm lighting", "sunlight streaming through gauzy curtains"],
+        "weather": [],
+        "time": ["morning light", "afternoon sun"],
+        "details": ["dust motes illuminated in the air", "teacup resting beside journals"],
+        "texture": ["weathered wood grain", "plush velvet seat"],
+        "props": ["vintage teapot", "open sketchbook with pressed flowers"],
+        "architecture": ["arched alcove", "built-in window seat"],
+        "fx": ["soft vignette", "gentle haze"],
+    },
+    "midnight_study": {
+        "label": "静寂の深夜書斎",
+        "setting": "indoor",
+        "themes": ["cozy_academia", "gothic_horror"],
+        "environment": ["candlelit study", "antique library room"],
+        "core": ["towering shelves", "glow from scattered candles"],
+        "lighting": ["warm candlelight", "single reading lamp spotlight"],
+        "weather": [],
+        "time": ["late evening", "midnight"],
+        "details": ["ink bottle and quill casting dramatic shadows", "maps pinned across the desk"],
+        "texture": ["polished mahogany", "aged parchment"],
+        "props": ["stack of occult tomes", "antique globe"],
+        "architecture": ["vaulted ceiling", "ornate fireplace"],
+        "fx": ["glowing motes of dust", "soft cinematic haze"],
+    },
+    "starlit_desert_bazaar": {
+        "label": "星明かりの砂漠バザール",
+        "setting": "outdoor",
+        "themes": ["desert_oasis_arabian_nights"],
+        "environment": ["moonlit desert marketplace", "lantern-lit bazaar tents"],
+        "core": ["billowing textiles", "jewel-toned carpets"],
+        "lighting": ["lantern glow", "starlight shimmer"],
+        "weather": ["warm night breeze"],
+        "time": ["night", "blue hour"],
+        "details": ["incense smoke drifting", "footprints in fine sand"],
+        "texture": ["woven fabrics", "polished brass"],
+        "props": ["hookah set", "overflowing spice baskets"],
+        "architecture": ["arched market stalls", "desert stone archways"],
+        "fx": ["floating embers", "soft motion blur of dancers"],
+    },
+    "oasis_courtyard": {
+        "label": "オアシスの静かな中庭",
+        "setting": "outdoor",
+        "themes": ["desert_oasis_arabian_nights", "tropical_resort"],
+        "environment": ["lush oasis courtyard", "water garden surrounded by mosaic tiles"],
+        "core": ["palm shadows", "cool marble benches"],
+        "lighting": ["golden-hour light", "dappled sunlight through palms"],
+        "weather": ["gentle breeze"],
+        "time": ["sunrise", "late evening"],
+        "details": ["ripples across still water", "petals floating in the pool"],
+        "texture": ["glazed tile", "smooth stone"],
+        "props": ["hanging lanterns", "ornate water jars"],
+        "architecture": ["carved archways", "intricate lattice screens"],
+        "fx": ["soft mist above the water", "sparkling light reflections"],
+    },
+    "enchanted_forest_clearing": {
+        "label": "木漏れ日の魔法の森",
+        "setting": "outdoor",
+        "themes": ["fantasy", "wafu_serenity_nature"],
+        "environment": ["sunlit forest clearing", "glade with luminescent flora"],
+        "core": ["floating firefly lights", "ancient tree roots"],
+        "lighting": ["sunlight filtering through leaves", "ethereal ambient glow"],
+        "weather": ["gentle breeze"],
+        "time": ["golden hour", "morning light"],
+        "details": ["petals drifting in the air", "soft moss cushioning the ground"],
+        "texture": ["mossy stone", "velvet foliage"],
+        "props": ["stone altar overgrown with vines", "hanging charms in the branches"],
+        "architecture": ["ancient stone pillars", "arch of intertwined branches"],
+        "fx": ["glowing motes of dust", "magical particles floating"],
+    },
+    "ancient_throne_hall": {
+        "label": "古の玉座の間",
+        "setting": "indoor",
+        "themes": ["fantasy", "space_opera"],
+        "environment": ["grand throne room", "ornate ceremonial hall"],
+        "core": ["draped banners", "gleaming marble floor"],
+        "lighting": ["dramatic spotlight", "sunlight through stained glass"],
+        "weather": [],
+        "time": ["midday", "afternoon sun"],
+        "details": ["floating dust caught by beams of light", "sparkling particles in the air"],
+        "texture": ["polished marble", "engraved metal"],
+        "props": ["ceremonial spears", "ornate throne"],
+        "architecture": ["vaulted ceiling", "towering columns"],
+        "fx": ["volumetric light rays", "soft haze"],
+    },
+    "misty_gothic_graveyard": {
+        "label": "霧に包まれた墓地",
+        "setting": "outdoor",
+        "themes": ["gothic_horror"],
+        "environment": ["misty graveyard at midnight", "ruined cemetery with leaning headstones"],
+        "core": ["stone angels", "withered roses"],
+        "lighting": ["moonlight breaking through fog", "cold blue rim light"],
+        "weather": ["thick fog", "chilly night air"],
+        "time": ["midnight"],
+        "details": ["curling mist around tombstones", "faint candle offerings"],
+        "texture": ["moss-covered stone", "damp earth"],
+        "props": ["wrought iron gates", "flickering grave candles"],
+        "architecture": ["gothic mausoleum", "crumbling chapel"],
+        "fx": ["low drifting fog", "ghostly light trails"],
+    },
+    "candlelit_cathedral": {
+        "label": "蝋燭に照らされた大聖堂",
+        "setting": "indoor",
+        "themes": ["gothic_horror", "cozy_academia"],
+        "environment": ["gothic cathedral nave", "candlelit sanctuary"],
+        "core": ["endless rows of pews", "stained glass glow"],
+        "lighting": ["candles casting long shadows", "soft moonlight through stained glass"],
+        "weather": [],
+        "time": ["night", "late evening"],
+        "details": ["smoke curling from incense", "echoes of distant choir"],
+        "texture": ["stone tiles", "aged wood"],
+        "props": ["candelabras", "sacred manuscripts"],
+        "architecture": ["flying buttresses", "vaulted arches"],
+        "fx": ["volumetric light rays", "soft vignette"],
+    },
+    "after_school_classroom": {
+        "label": "放課後の教室",
+        "setting": "indoor",
+        "themes": ["school"],
+        "environment": ["sunlit classroom", "orderly desks with personal touches"],
+        "core": ["chalkboard notes", "scattered textbooks"],
+        "lighting": ["late afternoon sun through large windows"],
+        "weather": [],
+        "time": ["afternoon sun", "golden hour"],
+        "details": ["dust motes highlighted by sunlight", "personal doodles on the desks"],
+        "texture": ["worn wooden desks", "polished linoleum"],
+        "props": ["stacked notebooks", "half-erased chalkboard"],
+        "architecture": ["corridor of lockers visible beyond", "traditional classroom layout"],
+        "fx": ["soft vignette", "warm bloom"],
+    },
+    "sunset_school_rooftop": {
+        "label": "夕暮れの校舎屋上",
+        "setting": "outdoor",
+        "themes": ["school", "cozy_academia"],
+        "environment": ["school rooftop overlooking city", "railing-lined terrace"],
+        "core": ["wind-swept flags", "distant skyline"],
+        "lighting": ["sunset glow", "soft rim lighting"],
+        "weather": ["gentle breeze"],
+        "time": ["sunset", "twilight"],
+        "details": ["chalk doodles on the floor", "potted plants cared for by students"],
+        "texture": ["concrete tiles", "wire fencing"],
+        "props": ["benches", "club equipment crates"],
+        "architecture": ["fenced rooftop", "utility shed"],
+        "fx": ["light leaks", "lens flare"],
+    },
+    "verdant_biodome_plaza": {
+        "label": "緑あふれるバイオドーム広場",
+        "setting": "mixed",
+        "themes": ["solapunk_art_nouveau", "space_opera"],
+        "environment": ["glass biodome plaza", "sunlit atrium with vertical gardens"],
+        "core": ["living architecture", "solar collectors shaped like leaves"],
+        "lighting": ["radiant skylight", "bioluminescent glow"],
+        "weather": [],
+        "time": ["daytime", "twilight"],
+        "details": ["water vapor rising from hydroponic pools", "soft hum of sustainable tech"],
+        "texture": ["polished glass", "lush moss"],
+        "props": ["floating planters", "interactive info pillars"],
+        "architecture": ["curving art nouveau arches", "transparent skybridge"],
+        "fx": ["light diffraction", "glowing particles"],
+    },
+    "art_nouveau_conservatory": {
+        "label": "アール・ヌーヴォーの温室",
+        "setting": "indoor",
+        "themes": ["solapunk_art_nouveau", "tropical_resort"],
+        "environment": ["sunlit conservatory", "greenhouse with ornate ironwork"],
+        "core": ["cascading plants", "art nouveau stained glass"],
+        "lighting": ["sunbeam breaking through glass", "soft diffused glow"],
+        "weather": [],
+        "time": ["morning", "afternoon"],
+        "details": ["mist rising from water features", "soft rustle of leaves"],
+        "texture": ["glossy foliage", "ornate tile"] ,
+        "props": ["hanging planters", "delicate fountains"],
+        "architecture": ["arched glass ceiling", "wrought iron lattice"],
+        "fx": ["soft lens flare", "floating pollen"],
+    },
+    "starship_bridge": {
+        "label": "宇宙船ブリッジ",
+        "setting": "indoor",
+        "themes": ["space_opera", "cyberpunk_futuristic"],
+        "environment": ["sleek starship bridge", "command center with panoramic window"],
+        "core": ["holographic displays", "crew consoles"],
+        "lighting": ["cool monitor glow", "strategic spotlights"],
+        "weather": [],
+        "time": ["deep space timelessness"],
+        "details": ["floating UI projections", "captain's chair highlighted by rim light"],
+        "texture": ["brushed alloy", "smooth composite panels"],
+        "props": ["navigation holomap", "control panels"],
+        "architecture": ["reinforced observation window", "tiered deck"],
+        "fx": ["starfield reflections", "glitch sparks"],
+    },
+    "orbital_hangar": {
+        "label": "軌道上のハンガーベイ",
+        "setting": "indoor",
+        "themes": ["space_opera"],
+        "environment": ["massive starship hangar", "maintenance bay with docking arms"],
+        "core": ["mechanical scaffolding", "cargo crates stacked high"],
+        "lighting": ["industrial floodlights", "warning beacons"],
+        "weather": [],
+        "time": ["artificial daylight"],
+        "details": ["steam vents releasing bursts", "workers silhouetted against light"],
+        "texture": ["metal grating", "painted warning stripes"],
+        "props": ["utility mechs", "hovering cargo pallets"],
+        "architecture": ["open hangar doors", "monolithic support beams"],
+        "fx": ["spark showers", "volumetric light shafts"],
+    },
+    "sunset_beach_boardwalk": {
+        "label": "夕暮れのビーチボードウォーク",
+        "setting": "outdoor",
+        "themes": ["tropical_resort", "desert_oasis_arabian_nights"],
+        "environment": ["sunset beach boardwalk", "palm-lined shoreline"],
+        "core": ["waves lapping against shore", "string lights overhead"],
+        "lighting": ["sunset glow", "warm fairy lights"],
+        "weather": ["gentle sea breeze"],
+        "time": ["sunset", "golden hour"],
+        "details": ["footprints in wet sand", "swaying palm shadows"],
+        "texture": ["weathered boardwalk", "sun-warmed sand"],
+        "props": ["driftwood seating", "tropical drink stand"],
+        "architecture": ["seaside cabana", "wooden pier"],
+        "fx": ["light leaks", "sparkling bokeh"],
+    },
+    "lush_poolside_terrace": {
+        "label": "リゾートのプールサイドテラス",
+        "setting": "outdoor",
+        "themes": ["tropical_resort", "solapunk_art_nouveau"],
+        "environment": ["luxury pool terrace", "tropical garden patio"],
+        "core": ["infinity pool edge", "lush foliage"],
+        "lighting": ["bright daylight", "soft lantern glow after sunset"],
+        "weather": ["warm breeze"],
+        "time": ["daytime", "evening"],
+        "details": ["sunlight sparkling on water", "condensation on chilled glasses"],
+        "texture": ["smooth stone tile", "woven lounge chairs"],
+        "props": ["plush lounge chairs", "floating candles"],
+        "architecture": ["open-air pavilion", "curved pergola"],
+        "fx": ["soft vignette", "lens flare"],
+    },
+    "bamboo_shrine_garden": {
+        "label": "竹林の神社庭園",
+        "setting": "outdoor",
+        "themes": ["wafu_serenity_nature", "fantasy"],
+        "environment": ["serene bamboo grove", "shrine garden with koi pond"],
+        "core": ["stone lanterns", "flowing water basin"],
+        "lighting": ["soft morning mist light", "paper lantern glow"],
+        "weather": ["gentle drizzle", "calm breeze"],
+        "time": ["morning", "dusk"],
+        "details": ["ripples from koi", "petals floating on water"],
+        "texture": ["smooth river stones", "mossy stepping path"],
+        "props": ["wooden ema plaques", "tea set ready for ceremony"],
+        "architecture": ["shinto torii gate", "wooden veranda"],
+        "fx": ["light mist", "floating petals"],
+    },
+    "moonlit_hot_spring": {
+        "label": "月明かりの温泉宿",
+        "setting": "mixed",
+        "themes": ["wafu_serenity_nature", "tropical_resort"],
+        "environment": ["outdoor hot spring", "ryokan courtyard with steam"],
+        "core": ["stone-lined onsen", "steam drifting upward"],
+        "lighting": ["moonlight", "paper lantern glow"],
+        "weather": ["crisp night air"],
+        "time": ["night", "late evening"],
+        "details": ["steam swirling gently", "bamboo ladles resting nearby"],
+        "texture": ["smooth wet stone", "wooden decking"],
+        "props": ["folded yukata", "sake tray"],
+        "architecture": ["ryokan sliding doors", "privacy screens"],
+        "fx": ["soft fog", "sparkling steam"],
+    },
+    "urban_twilight_street": {
+        "label": "黄昏の街角",
+        "setting": "outdoor",
+        "themes": [],
+        "environment": ["twilight city street", "quiet urban intersection"],
+        "core": ["car headlights reflecting on pavement", "silhouetted pedestrians"],
+        "lighting": ["streetlamp pools of light", "soft neon accents"],
+        "weather": ["recent rain sparkle"],
+        "time": ["twilight", "evening"],
+        "details": ["shop signs flickering to life", "steam rising from manhole"],
+        "texture": ["wet asphalt gloss", "brick facades"],
+        "props": ["parked bicycles", "bus stop shelter"],
+        "architecture": ["modern glass storefront", "historic row buildings"],
+        "fx": ["light leaks", "soft haze"],
+    },
+    "sunlit_highland_meadow": {
+        "label": "陽光の高原草原",
+        "setting": "outdoor",
+        "themes": [],
+        "environment": ["wildflower meadow", "rolling hills under open sky"],
+        "core": ["flowering grasses", "distant mountain silhouette"],
+        "lighting": ["bright daylight", "sunbeam breaking through clouds"],
+        "weather": ["gentle breeze"],
+        "time": ["morning", "afternoon"],
+        "details": ["petals drifting on the wind", "pollinator insects glinting in light"],
+        "texture": ["soft grasses", "rocky outcrop"],
+        "props": ["wooden fence", "picnic blanket"],
+        "architecture": ["rustic cottage in the distance"],
+        "fx": ["floating pollen", "cinematic haze"],
+    },
+}
 
-# ========================
-# 排他的な語彙グループ (更新済み)
-# ========================
-EXCLUSIVE_TAG_GROUPS = {
-    # 光源の種類 (自然光 / 人工光 / 幻想光)
-    "light_source_type": [
-        # --- 太陽光・自然光 ---
-        ["window daylight filtering through dust", "golden-hour light", "sunlight filtering through leaves (komorebi)", "high noon light", "blinding sunlight", "sunbeam breaking through clouds", "perfect sunny day"],
-        # --- 月光・夜の自然光 ---
-        ["ethereal moonlit ambience", "aurora borealis", "meteor shower"],
-        # --- 人工光 (現代・SF) ---
-        ["glowing monitor light on a face", "neon-soaked street at night", "colorful neon accent lights", "holographic glow", "fluorescent strip light", "strobe light effect", "blurry headlights in the rain", "streetlamp pools of light"],
-        # --- 炎・古典的な光 ---
-        ["flickering candlelight ambience", "soft fireplace glow", "paper lantern glow", "warm glow of paper lanterns", "lantern-lit lane at dusk"],
-        # --- 幻想的な光 ---
-        ["bioluminescent glow", "arcane glow from a spell", "light from glowing crystals", "magical particles floating", "floating particles of light"]
-    ],
+THEME_TO_PACKS: Dict[str, List[str]] = {}
+for pack_key, pack in CONCEPT_PACKS.items():
+    for theme in pack.get("themes", []) or []:
+        THEME_TO_PACKS.setdefault(theme, []).append(pack_key)
 
-    # 天候条件 (晴れ / 雨 / 雪 / 霧など)
-    "weather_condition": [
-        # --- 晴天系 ---
-        ["clear sky", "pollen breeze", "perfect sunny day", "bright daylight", "warm gentle breeze", "beautiful afterglow", "sunbeam breaking through clouds"],
-        # --- 雨天系 ---
-        ["light drizzle", "heavy rain", "sun shower", "rain-soaked boulevard", "raindrops on window", "wet pavement shine", "rain-soaked reflections", "thunderstorm with lightning"],
-        # --- 雪・氷結系 ---
-        ["gentle snowfall", "heavy blizzard", "snowy sidewalk", "diamond dust (ice crystals in air)", "frozen lake", "ancient glacier field"],
-        # --- 霧・霞系 ---
-        ["misty air", "thick morning fog", "hazy summer day", "bioluminescent fog", "hazy landscape"],
-        # --- 宇宙空間 (無天候) ---
-        ["calm vacuum", "endless night of space"]
-    ],
+THEME_CHOICES: List[str] = ["none", "おまかせ"] + sorted(list(THEME_TO_PACKS.keys()))
 
-    # 時間帯 (昼 / 夜)
+EXCLUSIVE_TAG_GROUPS: Dict[str, List[List[str]]] = {
     "time_of_day": [
-        # --- 昼間 ---
-        ["sunrise", "morning light", "high noon light", "golden hour", "afternoon sun", "bright daylight"],
-        # --- 夜間 ---
-        ["twilight", "blue hour", "deep midnight", "pre-dawn darkness", "late evening", "moonlit night", "starry night"]
+        ["sunrise", "morning", "morning light"],
+        ["afternoon", "afternoon sun", "daytime", "midday"],
+        ["sunset", "golden hour", "late evening", "twilight"],
+        ["night", "midnight", "blue hour", "deep space timelessness"],
     ],
-
-    # 特殊効果・光の表現
-    "environmental_effects": [
-        # --- 光線・光芒 ---
-        ["volumetric light rays", "dusty light rays", "sunbeams filtering through trees", "light shafts"],
-        # --- レンズ効果・人工的エフェクト ---
-        ["light leaks", "lens flare", "strobe light effect", "glitching effect on a screen", "chromatic aberration"],
-        # --- 粒子・浮遊物 ---
-        ["floating dust motes in sunbeam", "magical particles floating", "glowing motes of dust", "fire sparks and embers", "snow flurry in the air", "pollen breeze", "dandelion seeds drifting in the air"]
+    "weather": [
+        ["gentle breeze", "warm night breeze", "calm breeze"],
+        ["heavy rain", "rain-soaked", "recent rain sparkle"],
+        ["thick fog", "misty air", "soft fog"],
+        ["bright daylight", "artificial daylight", "moonlight"],
     ],
-
-    # 場所の基本的な状態 (屋内 / 屋外)
-    # ※これはシステム上フィルタリングされますが、念のため定義
-    "location_base": [
-        # --- 屋内系環境 ---
-        BG_ENV_INDOOR,
-        # --- 屋外系環境 ---
-        BG_ENV_OUTDOOR
-    ]
 }
 
-
-
-
-
-
+__all__ = [
+    "CONCEPT_PACKS",
+    "GENERAL_DEFAULTS",
+    "THEME_TO_PACKS",
+    "THEME_CHOICES",
+    "EXCLUSIVE_TAG_GROUPS",
+]

--- a/vocab/clothing_vocab.py
+++ b/vocab/clothing_vocab.py
@@ -1,90 +1,644 @@
-# clothing_vocab.py (v4 - 状態・新テーマ対応版)
-# - 「服装の状態」カテゴリを追加
-# - テーマパックをより具体的・多様なシチュエーションベースに刷新
+"""Vocabulary definitions for clothing concept packs.
 
-# ========================
-# 1. コア語彙 (色、素材、柄)
-# ========================
-COLORS = [
-    "black", "white", "gray", "charcoal", "ivory", "cream", "beige", "khaki", "off-white", "jet black", "snow white",
-    "red", "crimson", "scarlet", "wine", "burgundy", "maroon", "pink", "hot pink", "fuchsia", "rose", "coral", "blush pink", "magenta",
-    "blue", "navy blue", "royal blue", "sky blue", "cobalt", "cyan", "teal", "turquoise", "midnight blue", "baby blue", "periwinkle",
-    "green", "emerald", "olive", "forest green", "lime green", "mint green", "sage green", "jade", "seafoam green",
-    "yellow", "mustard", "gold", "orange", "apricot", "peach", "tangerine", "citrine",
-    "purple", "violet", "lavender", "mauve", "plum", "indigo", "lilac", "amethyst",
-    "brown", "chocolate", "tan", "caramel", "bronze", "coffee", "taupe",
-    "silver", "gunmetal", "metallic", "rose gold", "platinum", "iridescent", "holographic", "transparent", "clear"
-]
-MATERIALS = [
-    "cotton", "denim", "linen", "silk", "wool", "cashmere", "velvet", "leather", "suede", "corduroy", "hemp", "bamboo fabric",
-    "polyester", "nylon", "spandex", "lycra", "rayon", "acrylic", "latex", "PVC", "vinyl", "faux leather", "neoprene",
-    "lace", "chantilly lace", "chiffon", "organza", "tulle", "mesh", "fishnet", "georgette", "see-through fabric", "gossamer",
-    "knit", "ribbed knit", "cable knit", "fleece", "jersey", "chenille", "boucle",
-    "satin", "charmeuse", "brocade", "tweed", "sequin fabric", "faux fur", "terrycloth", "lamé", "jacquard", "crepe"
-]
-PATTERNS = [
-    "solid", "striped", "vertical stripes", "horizontal stripes", "pinstripe", "polka-dot", "checked", "gingham", "tartan", "plaid", "checkered",
-    "argyle", "chevron", "herringbone", "houndstooth", "grid", "geometric-pattern", "diamond-pattern", "cubist-pattern",
-    "floral", "botanical", "paisley", "leaf-print", "tropical-print", "rose-print", "cherry-blossom-print",
-    "animal-print", "leopard-print", "zebra-print", "snake-print", "tiger-print", "cheetah-print", "crocodile-print",
-    "abstract", "camouflage", "tie-dye", "gradient", "ombre", "star-pattern", "heart-pattern", "fair isle", "damask", "baroque", "cosmic-print", "ikat"
-]
+This module restructures the clothing vocabulary into themed concept packs so that
+prompt generation can select cohesive outfits without creating contradictory
+combinations (for example mixing a full dress with unrelated tops).
+"""
 
-# ========================
-# 2. 服の基本アイテム
-# ========================
-TOPS = ["t-shirt", "graphic tee", "blouse", "crop top", "hoodie", "turtleneck sweater", "off-the-shoulder top", "polo shirt", "henley shirt", "camisole", "tank top", "button-down shirt", "flannel shirt", "cashmere knit", "v-neck sweater", "cardigan", "sweatshirt", "tube top", "halter top", "peasant blouse", "tunic", "bustier top", "corset top", "bodysuit", "bandeau top", "smocked top", "wrap top"]
-BOTTOMS = ["jeans", "skinny jeans", "straight-leg jeans", "bootcut jeans", "ripped jeans", "flared jeans", "cargo pants", "pleated skirt", "mini skirt", "maxi skirt", "pencil skirt", "A-line skirt", "leggings", "biker shorts", "tailored trousers", "culottes", "denim shorts", "wide-leg pants", "corduroy pants", "yoga pants", "capri pants", "hotpants", "skort", "hip-huggers", "palazzo pants"]
-OUTERWEAR = ["denim jacket", "leather jacket", "biker jacket", "bomber jacket", "trench coat", "wool coat", "blazer", "parka", "puffer jacket", "windbreaker", "vest", "bolero", "duffle coat", "pea coat", "overcoat", "hooded jacket", "fleece jacket", "cape", "moto jacket", "longline cardigan", "kimono jacket", "anorak"]
-DRESSES_SETS = ["sundress", "A-line dress", "wrap dress", "pleated dress", "tailored blazer set", "jumpsuit", "romper", "maxi dress", "shirt dress", "sweater dress", "sheath dress", "blazer dress", "slip dress", "bodycon dress", "fit and flare dress", "babydoll dress", "little black dress", "cocktail dress", "evening gown", "skirt and blouse set", "two-piece set", "cutout dress", "qipao", "cheongsam", "kaftan"]
-LINGERIE = ["lace bra", "lace panties", "corset", "pvc corset", "leather corset", "waspie", "satin bustier", "lace bodysuit", "fishnet bodysuit", "silk chemise", "garter belt", "suspender belt", "latex mini dress", "fishnet stockings", "thigh-high stockings", "satin blindfold", "nipple tassels", "pasties", "open-cup bra", "shelf bra", "cupless bra", "strappy cage bra", "micro bikini", "crotchless panty", "open-back thong", "lace teddy", "sheer bodysuit", "satin corset", "longline bralette", "underwire bra and thong set", "babydoll", "g-string", "sheer kimono robe", "lace-trim yukata lingerie", "merry widow", "negligee"]
+from typing import Dict, List
 
-# ========================
-# 3. 装飾・スタイル
-# ========================
-STYLES = ["V-neck", "crew-neck", "scoop-neck", "boat-neck", "turtleneck", "high-neck", "halter", "sweetheart neckline", "plunge neckline", "cowl neck", "sleeveless", "short-sleeve", "long-sleeve", "cap-sleeve", "puffed-sleeve", "bell-sleeve", "raglan-sleeve", "kimono-sleeve", "bishop sleeve", "slim-fit", "loose-fit", "oversized", "A-line", "bodycon", "wrap-front", "peplum", "cropped", "high-waist", "low-rise", "empire waist", "draped", "ruched", "asymmetric hem", "high-low hem", "scalloped hem", "side-slit", "thigh-high slit", "front slit", "double slit", "open-back", "low-back", "lace-up back", "criss-cross back", "backless", "T-back", "strapless", "one-shoulder", "off-the-shoulder", "cold-shoulder", "button-front", "zip-front", "underboob cutout", "cleavage cutout", "hip cutout"]
-EMBELLISH = ["lace trim", "ruffles", "frills", "fringe", "piping", "contrast trim", "scalloped edges", "feathers", "fur trim", "bows", "ribbons", "sequins", "pearls", "crystals", "rhinestones", "studs", "grommets", "beads", "metal hardware", "embroidery", "pleats", "pintucks", "smocking", "ruching", "quilting", "cutouts", "sheer panels", "mesh inserts", "lace panels", "slashed details", "decorative buttons", "buckles", "zippers", "lace-up details", "hook-and-eye", "snap closure", "clasps", "appliques", "patches", "tassels", "chain details", "body chains", "contrast stitching", "epaulettes"]
-
-# ========================
-# 4. 露出表現・セクシー系アクセント
-# ========================
-ACCENTS_EROTIC = ["with garter straps", "with detachable garters", "with attached stockings", "with sheer gloves", "with a delicate choker", "with matching thong", "with lace-up back", "with open-crotch design", "with open-cup features", "with peekaboo panels", "with keyhole opening", "with O-ring details", "with metal rings", "with chain accents", "with delicate body chains", "with harness straps", "with bondage-style straps", "with lace-up sides", "with cutout hips", "with a plunging back", "held together by thin straps", "with strategic cutouts", "accented with pearls"]
-REVEAL_MILD = ["subtle sheer panels", "keyhole cutout", "low back", "shoulder cutouts", "back keyhole", "sheer sleeves", "a hint of sideboob", "modest cleavage", "slit on the leg", "off-shoulder revealing collarbones"]
-REVEAL_BOLD = ["see-through panels", "micro cutouts", "high-leg cut", "thong back", "deep plunge neckline", "cleavage window", "sideboob cutout", "underboob cutout", "hip cutouts", "backless design", "extremely short hemline", "navel cutout", "daringly high slit"]
-REVEAL_EXPLICIT = ["open sides", "sideboob cutouts", "barely-there straps", "ultra high-leg", "backless micro dress", "fully transparent", "cupless design", "crotchless design", "held by a single thread", "wardrobe malfunction", "nipple cutout", "completely sheer", "strategically placed rips", "unzipped front"]
-
-# ========================
-# 5. [新設] 服装の状態
-# ========================
-STATES = [
-    "wet", "soaking wet", "damp", "rain-soaked", "water-splashed", "dripping wet",
-    "dirty", "mud-stained", "torn", "ripped", "shredded", "worn-out", "tattered", "blood-stained",
-    "messy", "disheveled", "wrinkled", "askew", "loosened", "unbuttoned", "partially unzipped", "falling off shoulder",
-    "glowing", "shimmering", "wind-blown", "sun-bleached", "frozen", "covered in snow"
-]
-
-# ========================
-# 6. 排他グループ
-# ========================
-EXCLUSIVE_GROUPS = {
-    "season": {"summer": ["sundress", "linen", "bikini", "romper", "denim shorts", "tank top"], "winter": ["wool coat", "turtleneck sweater", "puffer jacket", "fleece", "cashmere knit", "corduroy"]},
-    "garment_slot": {"full_body": DRESSES_SETS, "tops": TOPS, "bottoms": BOTTOMS}
+# ---------------------------------------------------------------------------
+# Shared pools
+# ---------------------------------------------------------------------------
+PALETTE_DEFAULT_PROBABILITIES: Dict[str, float] = {
+    "colors": 0.9,
+    "materials": 0.85,
+    "patterns": 0.45,
+    "styles": 0.7,
+    "embellishments": 0.55,
 }
 
-# ========================
-# 7. [改修] テーマパック
-# ========================
-THEMES = {
-    "office_lady": {"tops": ["blouse", "button-down shirt", "knit top"], "bottoms": ["pencil skirt", "tailored trousers"], "outerwear": ["blazer"], "dresses_sets": ["sheath dress"], "patterns": ["solid", "pinstripe"]},
-    "beach_resort": {"dresses_sets": ["sundress", "maxi dress", "romper"], "tops": ["camisole", "off-the-shoulder top", "bandeau top"], "bottoms": ["denim shorts", "wrap skirt"], "materials": ["linen", "cotton", "chiffon"], "patterns": ["tropical-print", "floral"]},
-    "rainy_day": {"outerwear": ["trench coat", "raincoat", "windbreaker"], "bottoms": ["jeans"], "states": ["wet", "rain-soaked", "damp"], "patterns": ["solid"]},
-    "fantasy_battle": {"tops": ["corset top", "leather bustier"], "bottoms": ["leather pants", "armored skirt"], "outerwear": ["cape", "armored vest"], "materials": ["leather", "metal", "chainmail"], "embellish": ["studs", "buckles", "engraved patterns"]},
-    "cyberpunk_night": {"tops": ["techwear crop top", "holographic tank top"], "outerwear": ["bomber jacket with LED", "transparent vinyl jacket"], "bottoms": ["cargo pants with straps"], "materials": ["PVC", "nylon", "holographic"], "embellish": ["glowing piping", "buckles"]},
-    "traditional_japanese": {"dresses_sets": ["kimono", "yukata", "hakama skirt set"], "lingerie": ["sheer kimono robe"], "materials": ["silk", "satin", "cotton"], "patterns": ["sakura", "asanoha", "seigaiha"]},
-    "school_uniform": {"tops": ["sailor blouse", "button-down shirt"], "bottoms": ["pleated skirt"], "outerwear": ["blazer", "cardigan"], "patterns": ["plaid", "solid"]},
-    "gothic_lolita": {"dresses_sets": ["babydoll dress", "victorian goth dress"], "tops": ["lace blouse"], "bottoms": ["tiered skirt"], "materials": ["velvet", "lace", "cotton"], "embellish": ["ruffles", "bows", "lace trim"]},
-    "rock_concert": {"tops": ["graphic tee", "band t-shirt", "mesh top"], "bottoms": ["ripped jeans", "leather pants", "mini skirt"], "outerwear": ["biker jacket", "denim jacket"], "materials": ["denim", "leather", "mesh"]},
-    "winter_date": {"outerwear": ["wool coat", "duffle coat", "puffer jacket"], "tops": ["turtleneck sweater", "cashmere knit"], "bottoms": ["pleated skirt", "wool trousers"], "states": ["covered in snow"]},
-    "secret_agent": {"dresses_sets": ["bodycon dress", "evening gown"], "styles": ["thigh-high slit", "backless"], "materials": ["satin", "velvet"], "accents_erotic": ["with garter straps"]},
-    "gym_workout": {"tops": ["sports bra", "tank top"], "bottoms": ["leggings", "yoga pants", "biker shorts"], "materials": ["spandex", "nylon", "jersey"]}
+OPTIONAL_DETAIL_PROBABILITY: float = 0.45
+STATE_DETAIL_PROBABILITY: float = 0.3
+OUTERWEAR_SELECTION_PROBABILITY: float = 0.25
+
+STATE_TAGS: List[str] = [
+    "wet",
+    "rain-soaked",
+    "damp",
+    "water-splashed",
+    "dripping wet",
+    "wind-blown",
+    "sun-bleached",
+    "frozen",
+    "covered in snow",
+    "glowing",
+    "shimmering",
+]
+
+EROTIC_ACCENTS: List[str] = [
+    "with garter straps",
+    "with detachable garters",
+    "with attached stockings",
+    "with sheer gloves",
+    "with a delicate choker",
+    "with matching thong",
+    "with lace-up back",
+    "with open-crotch design",
+    "with peekaboo panels",
+    "with keyhole opening",
+    "with O-ring details",
+    "with metal rings",
+    "with chain accents",
+    "with delicate body chains",
+    "with harness straps",
+    "with bondage-style straps",
+    "with lace-up sides",
+    "with cutout hips",
+    "with a plunging back",
+    "accented with pearls",
+]
+
+EXPOSURE_TAGS: Dict[str, List[str]] = {
+    "mild": [
+        "subtle sheer panels",
+        "keyhole cutout",
+        "low back",
+        "shoulder cutouts",
+        "back keyhole",
+        "sheer sleeves",
+        "a hint of sideboob",
+        "modest cleavage",
+        "slit on the leg",
+        "off-shoulder revealing collarbones",
+    ],
+    "bold": [
+        "see-through panels",
+        "micro cutouts",
+        "high-leg cut",
+        "thong back",
+        "deep plunge neckline",
+        "cleavage window",
+        "sideboob cutout",
+        "underboob cutout",
+        "hip cutouts",
+        "backless design",
+        "daringly high slit",
+    ],
+    "explicit": [
+        "open sides",
+        "barely-there straps",
+        "ultra high-leg",
+        "backless micro dress",
+        "fully transparent",
+        "cupless design",
+        "crotchless design",
+        "held by a single thread",
+        "nipple cutout",
+        "completely sheer",
+        "strategically placed rips",
+        "unzipped front",
+    ],
 }
+
+# ---------------------------------------------------------------------------
+# Concept packs
+# ---------------------------------------------------------------------------
+CONCEPT_PACKS: Dict[str, Dict[str, Dict[str, object]]] = {
+    "dresses": {
+        "romantic_garden_party": {
+            "core": ["floral-print", "fit and flare dress"],
+            "choices": {
+                "dresses": ["sundress", "A-line dress"],
+            },
+            "palette": {
+                "colors": ["soft pink", "white", "sky blue"],
+                "materials": ["cotton", "chiffon", "linen"],
+                "patterns": ["floral", "botanical"],
+                "styles": ["sleeveless", "knee-length", "flowy silhouette"],
+                "embellishments": ["lace trim", "ruffles", "belted waist"],
+            },
+            "optional_details": ["delicate waist ribbon", "matching sun hat"],
+            "states": [],
+        },
+        "executive_pencil_dress": {
+            "core": ["tailored fit", "sleek silhouette"],
+            "choices": {
+                "dresses": ["sheath dress", "bodycon dress"],
+            },
+            "palette": {
+                "colors": ["navy blue", "charcoal", "wine"],
+                "materials": ["wool", "stretch cotton", "silk blend"],
+                "patterns": ["solid", "pinstripe"],
+                "styles": ["knee-length", "cap-sleeve", "high-neck"],
+                "embellishments": ["waist belt", "covered buttons"],
+            },
+            "optional_details": ["minimalist jewelry accent", "structured peplum"],
+        },
+        "boho_maxi_dress": {
+            "core": ["bohemian", "flowing layers"],
+            "choices": {
+                "dresses": ["maxi dress", "wrap dress"],
+            },
+            "palette": {
+                "colors": ["earthy brown", "sage green", "sunset orange"],
+                "materials": ["cotton", "gauze", "silk"],
+                "patterns": ["paisley", "floral", "tie-dye"],
+                "styles": ["long-sleeve", "wrap-front", "tiered hem"],
+                "embellishments": ["fringe", "tassels", "embroidery"],
+            },
+            "optional_details": ["layered necklaces", "wide waist sash"],
+        },
+        "sleek_evening_gown": {
+            "core": ["elegant evening", "floor-length"],
+            "choices": {
+                "dresses": ["evening gown", "little black dress"],
+            },
+            "palette": {
+                "colors": ["black", "deep crimson", "emerald"],
+                "materials": ["silk", "velvet", "satin"],
+                "patterns": ["solid", "ombre"],
+                "styles": ["backless", "thigh-high slit", "mermaid silhouette"],
+                "embellishments": ["sequins", "crystals", "beaded straps"],
+            },
+            "optional_details": ["opera gloves", "draped shawl"],
+            "exposure_bias": "bold",
+        },
+        "cyberpunk_bodycon_dress": {
+            "core": ["futuristic", "techwear accents"],
+            "choices": {
+                "dresses": ["bodycon dress", "techwear mini dress"],
+            },
+            "palette": {
+                "colors": ["black", "electric blue", "neon magenta"],
+                "materials": ["PVC", "latex", "neoprene"],
+                "patterns": ["geometric-pattern", "circuit motif"],
+                "styles": ["high-neck", "cutout panels", "asymmetric hem"],
+                "embellishments": ["glowing piping", "buckles", "metal hardware"],
+            },
+            "optional_details": ["holographic visor", "fingerless gloves"],
+            "exposure_bias": "bold",
+        },
+        "victorian_gothic_dress": {
+            "core": ["victorian goth", "layered lace"],
+            "choices": {
+                "dresses": ["babydoll dress", "gothic lolita dress"],
+            },
+            "palette": {
+                "colors": ["jet black", "wine", "ivory"],
+                "materials": ["velvet", "lace", "cotton"],
+                "patterns": ["baroque", "damask"],
+                "styles": ["long-sleeve", "high-neck", "tiered skirt"],
+                "embellishments": ["lace trim", "bows", "ruffles"],
+            },
+            "optional_details": ["lace gloves", "mini top hat"],
+        },
+        "winter_knit_dress": {
+            "core": ["cozy knit", "winter date"],
+            "choices": {
+                "dresses": ["sweater dress", "turtleneck sweater dress"],
+            },
+            "palette": {
+                "colors": ["cream", "dusty rose", "soft gray"],
+                "materials": ["wool", "cashmere", "fleece"],
+                "patterns": ["fair isle", "solid"],
+                "styles": ["long-sleeve", "fitted silhouette", "knee-length"],
+                "embellishments": ["cable knit texture", "knit belt"],
+            },
+            "optional_details": ["cozy scarf", "fuzzy leg warmers"],
+            "states": ["covered in snow"],
+        },
+        "traditional_kimono_dress": {
+            "core": ["kimono", "obi sash"],
+            "choices": {
+                "dresses": ["kimono", "yukata", "furisode"],
+            },
+            "palette": {
+                "colors": ["crimson", "indigo", "soft gold"],
+                "materials": ["silk", "satin", "cotton"],
+                "patterns": ["cherry-blossom-print", "asanoha", "seigaiha"],
+                "styles": ["long-sleeve", "floor-length", "layered"],
+                "embellishments": ["embroidery", "obijime cord", "kanzashi adornment"],
+            },
+            "optional_details": ["floral hair ornament", "tabi socks"],
+        },
+        "athletic_bodysuit": {
+            "core": ["performance wear", "streamlined"],
+            "choices": {
+                "dresses": ["bodysuit", "unitard"],
+            },
+            "palette": {
+                "colors": ["slate gray", "cerulean", "white"],
+                "materials": ["spandex", "nylon", "lycra"],
+                "patterns": ["color-block", "gradient"],
+                "styles": ["zip-front", "thumb holes", "panelled"],
+                "embellishments": ["reflective piping", "mesh inserts"],
+            },
+            "optional_details": ["supportive sports belt", "performance gloves"],
+            "exposure_bias": "mild",
+        },
+        "arcane_battle_dress": {
+            "core": ["fantasy battle", "armored bodice"],
+            "choices": {
+                "dresses": ["armored gown", "battle mage robe"],
+            },
+            "palette": {
+                "colors": ["midnight blue", "gunmetal", "amethyst"],
+                "materials": ["leather", "metal", "brocade"],
+                "patterns": ["arcane sigils", "geometric-pattern"],
+                "styles": ["structured skirt", "high slit", "layered plates"],
+                "embellishments": ["studs", "engraved plates", "chainmail trim"],
+            },
+            "optional_details": ["spell scroll belt", "pauldron accents"],
+        },
+    },
+    "separates": {
+        "modern_office_attire": {
+            "core": ["professional ensemble"],
+            "choices": {
+                "tops": [["silk blouse", "long-sleeve"], ["button-down shirt", "tucked in"], ["knit top", "fitted"]],
+                "bottoms": [["pencil skirt", "high-waist"], ["tailored trousers", "pressed creases"]],
+            },
+            "palette": {
+                "colors": ["ivory", "charcoal", "navy blue"],
+                "materials": ["silk", "cotton", "wool"],
+                "patterns": ["solid", "pinstripe"],
+                "styles": ["waist-cinched", "knee-length", "structured"],
+                "embellishments": ["waist belt", "minimalist buttons"],
+            },
+            "optional_details": ["delicate neck scarf", "minimal jewelry"],
+        },
+        "street_denim_layer": {
+            "core": ["street fashion", "layered casual"],
+            "choices": {
+                "tops": [["graphic tee", "oversized"], ["cropped hoodie", "drawstring"], ["tank top", "layered under jacket"]],
+                "bottoms": [["ripped jeans"], ["denim shorts", "distressed hem"], ["cargo pants", "strap details"]],
+            },
+            "palette": {
+                "colors": ["black", "ash gray", "electric blue"],
+                "materials": ["denim", "cotton", "mesh"],
+                "patterns": ["graphic print", "striped"],
+                "styles": ["relaxed fit", "high-waist", "cropped"],
+                "embellishments": ["zippers", "buckles", "contrast stitching"],
+            },
+            "optional_details": ["layered chains", "fingerless gloves"],
+        },
+        "preppy_school_uniform": {
+            "core": ["school uniform", "neat pleats"],
+            "choices": {
+                "tops": [["sailor blouse", "ribbon tie"], ["button-down shirt", "cardigan overlay"]],
+                "bottoms": [["pleated skirt"], ["plaid skirt"]],
+            },
+            "palette": {
+                "colors": ["navy", "white", "burgundy"],
+                "materials": ["cotton", "wool blend"],
+                "patterns": ["plaid", "solid"],
+                "styles": ["long-sleeve", "pleated", "collared"],
+                "embellishments": ["ribbons", "decorative buttons", "badge emblem"],
+            },
+            "optional_details": ["knee-high socks", "school satchel"],
+        },
+        "athleisure_training_set": {
+            "core": ["training set", "sporty"],
+            "choices": {
+                "tops": [["sports bra", "supportive straps"], ["tank top", "breathable mesh"]],
+                "bottoms": [["leggings", "high-waist"], ["biker shorts", "compression fit"], ["yoga pants", "panelled"]],
+            },
+            "palette": {
+                "colors": ["black", "teal", "coral"],
+                "materials": ["spandex", "nylon", "jersey"],
+                "patterns": ["color-block", "ombre"],
+                "styles": ["bodycon", "crop length", "supportive waistband"],
+                "embellishments": ["mesh inserts", "reflective piping"],
+            },
+            "optional_details": ["sweatband", "sports smartwatch"],
+            "exposure_bias": "mild",
+        },
+        "punk_rock_stagewear": {
+            "core": ["stage ready", "edgy"],
+            "choices": {
+                "tops": [["mesh top", "strappy"], ["band t-shirt", "cropped"], ["corset top", "lace-up front"]],
+                "bottoms": [["leather pants", "skin-tight"], ["mini skirt", "studded belt"]],
+            },
+            "palette": {
+                "colors": ["black", "scarlet", "metallic"],
+                "materials": ["leather", "PVC", "mesh"],
+                "patterns": ["solid", "grunge print"],
+                "styles": ["bodycon", "high-waist", "asymmetric hem"],
+                "embellishments": ["studs", "chains", "zippers"],
+            },
+            "optional_details": ["fishnet stockings", "choker necklace"],
+            "exposure_bias": "bold",
+        },
+        "gothic_lolita_coord": {
+            "core": ["layered lolita", "sweet goth"],
+            "choices": {
+                "tops": [["lace blouse", "puffed-sleeve"], ["high-neck blouse", "ruffled collar"]],
+                "bottoms": [["tiered skirt", "petticoat"]],
+            },
+            "palette": {
+                "colors": ["black", "wine", "cream"],
+                "materials": ["lace", "velvet", "cotton"],
+                "patterns": ["baroque", "floral"] ,
+                "styles": ["long-sleeve", "corseted waist", "layered"],
+                "embellishments": ["bows", "lace trim", "frills"],
+            },
+            "optional_details": ["bonnet headpiece", "lace parasol"],
+        },
+        "beach_resort_coord": {
+            "core": ["resort wear", "breezy layers"],
+            "choices": {
+                "tops": [["off-the-shoulder top", "ruffled"], ["bandeau top", "twist front"], ["light camisole", "flowy"]],
+                "bottoms": [["wrap skirt", "side slit"], ["linen shorts", "tie waist"]],
+            },
+            "palette": {
+                "colors": ["turquoise", "white", "sunny yellow"],
+                "materials": ["linen", "cotton", "chiffon"],
+                "patterns": ["tropical-print", "floral", "gradient"],
+                "styles": ["lightweight", "high-low hem", "off-the-shoulder"],
+                "embellishments": ["shell accents", "beaded tassels"],
+            },
+            "optional_details": ["wide-brim hat", "ankle bracelet"],
+            "states": ["sun-kissed glow"],
+        },
+        "winter_layered_knit": {
+            "core": ["layered knitwear", "cozy"],
+            "choices": {
+                "tops": [["turtleneck sweater", "chunky knit"], ["cashmere knit", "long-sleeve"]],
+                "bottoms": [["wool trousers", "pleated front"], ["thermal leggings", "lined"]],
+            },
+            "palette": {
+                "colors": ["cream", "dusty mauve", "forest green"],
+                "materials": ["wool", "cashmere", "fleece"],
+                "patterns": ["solid", "fair isle"],
+                "styles": ["relaxed fit", "layered", "tucked"],
+                "embellishments": ["cable knit texture", "faux fur trim"],
+            },
+            "optional_details": ["knit mittens", "wool beret"],
+            "states": ["covered in snow"],
+        },
+        "fantasy_battle_armor": {
+            "core": ["armored elegance", "battle ready"],
+            "choices": {
+                "tops": [["corset top", "reinforced plates"], ["leather bustier", "strapped"]],
+                "bottoms": [["armored skirt", "layered plates"], ["leather pants", "buckled"]],
+            },
+            "palette": {
+                "colors": ["steel", "midnight blue", "crimson"],
+                "materials": ["leather", "metal", "brocade"],
+                "patterns": ["geometric-pattern", "engraved runes"],
+                "styles": ["cinched waist", "high slit", "structured panels"],
+                "embellishments": ["studs", "buckles", "chainmail trim"],
+            },
+            "optional_details": ["armored gauntlets", "battle cloak"],
+        },
+        "secret_agent_suit": {
+            "core": ["sleek agent", "stealthy"],
+            "choices": {
+                "tops": [["tailored bodysuit", "zip-front"], ["silk blouse", "hidden placket"]],
+                "bottoms": [["tailored trousers", "ankle-slit"], ["sleek pencil skirt", "side slit"]],
+            },
+            "palette": {
+                "colors": ["black", "graphite", "deep navy"],
+                "materials": ["stretch twill", "silk", "neoprene"],
+                "patterns": ["solid", "subtle herringbone"],
+                "styles": ["bodycon", "high slit", "structured"],
+                "embellishments": ["concealed holster harness", "minimalist belt"],
+            },
+            "optional_details": ["glossy gloves", "earpiece"],
+            "exposure_bias": "bold",
+        },
+        "rainy_day_layers": {
+            "core": ["weather ready", "layered"],
+            "choices": {
+                "tops": [["turtleneck sweater", "cozy"], ["long-sleeve tee", "layered"], ["lightweight sweater", "ribbed"]],
+                "bottoms": [["jeans", "ankle crop"], ["tailored trousers", "water resistant"]],
+            },
+            "palette": {
+                "colors": ["charcoal", "navy", "olive"],
+                "materials": ["cotton", "wool blend", "technical fabric"],
+                "patterns": ["solid", "pinstripe"],
+                "styles": ["layered", "ankle-length", "high-waist"],
+                "embellishments": ["storm flap", "sealed seams"],
+            },
+            "optional_details": ["cozy scarf", "weatherproof boots"],
+            "states": ["rain-soaked"],
+            "outerwear_hint": "rainproof_trench",
+        },
+        "solarpunk_breeze": {
+            "core": ["solarpunk", "organic silhouettes"],
+            "choices": {
+                "tops": [["sleeveless tunic", "draped"], ["wrap top", "asymmetric hem"]],
+                "bottoms": [["pleated skirt", "lightweight"], ["wide-leg pants", "flowing panels"]],
+            },
+            "palette": {
+                "colors": ["mint green", "sunlit gold", "off-white"],
+                "materials": ["bamboo fabric", "cotton", "silk"],
+                "patterns": ["botanical", "geometric-pattern"],
+                "styles": ["flowy", "high-waist", "layered"],
+                "embellishments": ["embroidery", "beads", "leafy appliques"],
+            },
+            "optional_details": ["bioluminescent accents", "seed pod jewelry"],
+        },
+    },
+    "outerwear": {
+        "tailored_blazer": {
+            "core": ["structured blazer"],
+            "choices": {
+                "outerwear": ["blazer", "longline blazer"],
+            },
+            "palette": {
+                "colors": ["charcoal", "camel", "navy"],
+                "materials": ["wool", "tweed", "cotton blend"],
+                "styles": ["waist-cinched", "double-breasted", "sleek lapels"],
+                "embellishments": ["padded shoulders", "polished buttons"],
+            },
+            "optional_details": ["pocket square", "skinny belt"],
+        },
+        "cozy_wool_coat": {
+            "core": ["warm outerwear"],
+            "choices": {
+                "outerwear": ["wool coat", "duffle coat", "puffer jacket"],
+            },
+            "palette": {
+                "colors": ["cream", "burgundy", "forest green"],
+                "materials": ["wool", "cashmere", "faux fur"],
+                "styles": ["longline", "hooded", "wrap-front"],
+                "embellishments": ["toggle closures", "faux fur trim"]
+            },
+            "optional_details": ["knit scarf", "cozy earmuffs"],
+        },
+        "edgy_biker_jacket": {
+            "core": ["biker jacket", "edgy layer"],
+            "choices": {
+                "outerwear": ["leather jacket", "biker jacket", "moto jacket"],
+            },
+            "palette": {
+                "colors": ["black", "charcoal", "oxblood"],
+                "materials": ["leather", "faux leather", "suede"],
+                "styles": ["cropped", "asymmetric zipper", "fitted"],
+                "embellishments": ["studs", "zip hardware", "buckled straps"],
+            },
+            "optional_details": ["shoulder spikes", "chain epaulettes"],
+        },
+        "techwear_translucent_parka": {
+            "core": ["techwear parka", "futuristic"],
+            "choices": {
+                "outerwear": ["transparent vinyl jacket", "bomber jacket with LED", "anorak"],
+            },
+            "palette": {
+                "colors": ["transparent", "holographic", "electric blue"],
+                "materials": ["PVC", "nylon", "neoprene"],
+                "styles": ["hooded", "oversized", "modular"],
+                "embellishments": ["glowing piping", "utility straps", "zippered pockets"],
+            },
+            "optional_details": ["tech visor", "cybernetic armband"],
+        },
+        "romantic_lace_shawl": {
+            "core": ["delicate cover-up"],
+            "choices": {
+                "outerwear": ["lace shawl", "sheer cape", "bolero"],
+            },
+            "palette": {
+                "colors": ["ivory", "blush", "lavender"],
+                "materials": ["lace", "tulle", "chiffon"],
+                "styles": ["shoulder drape", "open-front", "short-sleeve"],
+                "embellishments": ["lace trim", "scalloped edges", "pearls"],
+            },
+            "optional_details": ["delicate brooch", "floral corsage"],
+        },
+        "sporty_track_jacket": {
+            "core": ["athletic layer"],
+            "choices": {
+                "outerwear": ["track jacket", "windbreaker"],
+            },
+            "palette": {
+                "colors": ["white", "teal", "coral"],
+                "materials": ["nylon", "polyester", "spandex"],
+                "styles": ["zip-front", "stand collar", "cropped"],
+                "embellishments": ["reflective stripes", "contrast piping"],
+            },
+            "optional_details": ["thumb hole cuffs", "hood hidden in collar"],
+        },
+        "armored_cloak": {
+            "core": ["battle cloak"],
+            "choices": {
+                "outerwear": ["cape", "armored vest", "hooded cloak"],
+            },
+            "palette": {
+                "colors": ["black", "midnight blue", "bronze"],
+                "materials": ["leather", "brocade", "metal"],
+                "styles": ["floor-length", "hooded", "shoulder plating"],
+                "embellishments": ["engraved clasps", "chainmail edging"],
+            },
+            "optional_details": ["sigil brooch", "fur-lined collar"],
+        },
+        "rainproof_trench": {
+            "core": ["raincoat", "weather shield"],
+            "choices": {
+                "outerwear": ["trench coat", "raincoat"],
+            },
+            "palette": {
+                "colors": ["charcoal", "navy", "olive"],
+                "materials": ["waterproof fabric", "coated cotton"],
+                "styles": ["belted", "storm flap", "hooded"],
+                "embellishments": ["sealed seams", "epaulettes"],
+            },
+            "optional_details": ["transparent umbrella", "waterproof bag"],
+        },
+        "kimono_haori": {
+            "core": ["haori jacket"],
+            "choices": {
+                "outerwear": ["haori", "kimono jacket"],
+            },
+            "palette": {
+                "colors": ["indigo", "vermillion", "cream"],
+                "materials": ["silk", "cotton", "brocade"],
+                "styles": ["three-quarter sleeve", "open-front", "patterned lining"],
+                "embellishments": ["embroidered crest", "woven sash"],
+            },
+            "optional_details": ["sensu fan", "obi-inspired belt"],
+        },
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Theme mapping (UI compatibility)
+# ---------------------------------------------------------------------------
+THEME_TO_PACKS: Dict[str, Dict[str, List[str]]] = {
+    "office_lady": {
+        "dresses": ["executive_pencil_dress"],
+        "separates": ["modern_office_attire"],
+        "outerwear": ["tailored_blazer"],
+    },
+    "beach_resort": {
+        "dresses": ["romantic_garden_party", "boho_maxi_dress"],
+        "separates": ["beach_resort_coord"],
+        "outerwear": ["romantic_lace_shawl"],
+    },
+    "rainy_day": {
+        "dresses": ["winter_knit_dress"],
+        "separates": ["rainy_day_layers"],
+        "outerwear": ["rainproof_trench", "cozy_wool_coat"],
+    },
+    "fantasy_battle": {
+        "dresses": ["arcane_battle_dress"],
+        "separates": ["fantasy_battle_armor"],
+        "outerwear": ["armored_cloak"],
+    },
+    "cyberpunk_night": {
+        "dresses": ["cyberpunk_bodycon_dress"],
+        "separates": ["street_denim_layer"],
+        "outerwear": ["techwear_translucent_parka"],
+    },
+    "traditional_japanese": {
+        "dresses": ["traditional_kimono_dress"],
+        "separates": ["solarpunk_breeze"],
+        "outerwear": ["kimono_haori"],
+    },
+    "school_uniform": {
+        "dresses": ["romantic_garden_party"],
+        "separates": ["preppy_school_uniform"],
+        "outerwear": ["tailored_blazer"],
+    },
+    "gothic_lolita": {
+        "dresses": ["victorian_gothic_dress"],
+        "separates": ["gothic_lolita_coord"],
+        "outerwear": ["romantic_lace_shawl"],
+    },
+    "rock_concert": {
+        "dresses": ["sleek_evening_gown", "cyberpunk_bodycon_dress"],
+        "separates": ["punk_rock_stagewear"],
+        "outerwear": ["edgy_biker_jacket"],
+    },
+    "winter_date": {
+        "dresses": ["winter_knit_dress"],
+        "separates": ["winter_layered_knit"],
+        "outerwear": ["cozy_wool_coat"],
+    },
+    "secret_agent": {
+        "dresses": ["sleek_evening_gown", "athletic_bodysuit"],
+        "separates": ["secret_agent_suit"],
+        "outerwear": ["tailored_blazer", "rainproof_trench"],
+    },
+    "gym_workout": {
+        "dresses": ["athletic_bodysuit"],
+        "separates": ["athleisure_training_set"],
+        "outerwear": ["sporty_track_jacket"],
+    },
+}
+
+THEME_CHOICES: List[str] = ["none"] + sorted(list(THEME_TO_PACKS.keys()))
+
+__all__ = [
+    "CONCEPT_PACKS",
+    "THEME_TO_PACKS",
+    "THEME_CHOICES",
+    "EXPOSURE_TAGS",
+    "EROTIC_ACCENTS",
+    "STATE_TAGS",
+    "PALETTE_DEFAULT_PROBABILITIES",
+    "OPTIONAL_DETAIL_PROBABILITY",
+    "STATE_DETAIL_PROBABILITY",
+    "OUTERWEAR_SELECTION_PROBABILITY",
+]

--- a/vocab/pose_emotion_vocab.py
+++ b/vocab/pose_emotion_vocab.py
@@ -157,40 +157,80 @@ EXPRESSION_MODES: Dict[str, Dict[str, List[str]]] = {
 EMOTION_THEME_PACKS: Dict[str, Dict[str, object]] = {
     "Jubilant_Joy": {
         "tags": {
-            "pose": ["jumping", "dancing", "twirling", "arms outstretched", "leaping"],
-            "expression": ["ecstatic", "beaming", "laughing", "joyful", "sparkling eyes"],
-            "camera": ["wide angle", "full shot", "dynamic pose"],
+            "pose": [
+                "jumping with arms wide",
+                "dancing mid-spin",
+                "cheerful skip",
+                "hands raised in celebration",
+                "leaping forward",
+            ],
+            "expression": [
+                "radiant smile",
+                "beaming eyes",
+                "joyful laughter",
+                "sparkling eyes",
+                "grinning with delight",
+            ],
+            "camera": ["wide angle", "dynamic full-body shot", "slightly tilted celebration shot"],
+            "accent": ["confetti burst", "sunlit glow"],
         },
         "focus": {
-            "pose": ["pose_dynamic", "pose_standing", "pose_sitting"],
+            "pose": ["pose_dynamic", "pose_standing"],
             "expression": ["joy"],
         },
         "conflicts": {
             "pose_categories": ["pose_lying"],
-            "mood_labels": ["sadness", "anger"],
+            "mood_labels": ["sadness", "anger", "erotic", "allure"],
+            "tags": ["tears", "crying", "melancholy", "grimace"],
         },
     },
     "Quiet_Sorrow": {
         "tags": {
-            "pose": ["hugging knees", "sitting on the floor", "slumped shoulders", "head down", "covering face"],
-            "expression": ["melancholy", "crying", "tearful", "sorrowful", "furrowed brows"],
-            "camera": ["close-up", "from above", "rainy"],
+            "pose": [
+                "hugging knees close",
+                "sitting curled on the floor",
+                "slumped shoulders",
+                "head bowed and hands clasped",
+                "leaning against a wall in solitude",
+            ],
+            "expression": [
+                "softly crying",
+                "tearful gaze",
+                "downturned lips",
+                "glassy eyes",
+                "somber expression",
+            ],
+            "camera": ["intimate close-up", "overhead melancholy shot", "window light with rain"],
+            "accent": ["raindrops on cheeks", "dim ambient glow"],
         },
         "focus": {
-            "pose": ["pose_sitting", "pose_lying", "pose_standing"],
+            "pose": ["pose_sitting", "pose_lying"],
             "expression": ["sadness"],
         },
         "conflicts": {
             "pose_categories": ["pose_dynamic"],
-            "mood_labels": ["joy", "anger", "erotic"],
-            "camera_tags": ["dutch angle"],
+            "mood_labels": ["joy", "anger", "erotic", "allure"],
+            "camera_tags": ["dutch angle", "hero shot"],
+            "tags": ["radiant smile", "laughing", "celebratory"],
         },
     },
     "Burning_Anger": {
         "tags": {
-            "pose": ["power stance", "fist clenched", "fighting stance", "pointing"],
-            "expression": ["furious", "glaring", "scowling", "shouting", "enraged"],
-            "camera": ["dutch angle", "low angle", "dramatic lighting"],
+            "pose": [
+                "power stance with clenched fists",
+                "forward-leaning confrontation",
+                "shouting mid-gesture",
+                "arms thrown wide in fury",
+            ],
+            "expression": [
+                "furious glare",
+                "snarling",
+                "teeth bared",
+                "brows sharply furrowed",
+                "shouting with intensity",
+            ],
+            "camera": ["low angle", "dynamic dutch angle", "high-contrast lighting"],
+            "accent": ["embers flying", "crackling aura"],
         },
         "focus": {
             "pose": ["pose_dynamic", "pose_standing"],
@@ -198,50 +238,91 @@ EMOTION_THEME_PACKS: Dict[str, Dict[str, object]] = {
         },
         "conflicts": {
             "pose_categories": ["pose_lying"],
-            "mood_labels": ["joy", "sadness"],
+            "mood_labels": ["joy", "sadness", "erotic"],
+            "tags": ["tearful", "soft smile", "bashful"],
         },
     },
     "Seductive_Allure": {
         "tags": {
-            "pose": ["arched back", "looking over shoulder", "touching hair", "one leg forward"],
-            "expression": ["seductive", "flirtatious", "biting lip", "winking", "smirk"],
-            "camera": ["medium close-up", "bust shot", "soft lighting"],
+            "pose": [
+                "arched back with one hand in hair",
+                "leaning forward with inviting gaze",
+                "seated with crossed legs and tilted chin",
+                "standing with hip cocked",
+            ],
+            "expression": [
+                "sultry smile",
+                "languid eyes",
+                "biting lip",
+                "playful wink",
+                "half-lidded gaze",
+            ],
+            "camera": ["medium close-up", "bust shot", "soft rim lighting"],
+            "accent": ["softly glowing highlights", "perfumed haze"],
         },
         "focus": {
             "pose": ["pose_standing", "pose_sitting", "pose_dynamic"],
             "expression": ["allure"],
         },
         "conflicts": {
-            "mood_labels": ["anger", "sadness"],
+            "pose_categories": ["pose_lying"],
+            "mood_labels": ["sadness", "anger"],
+            "tags": ["tears", "rage", "awkward grin"],
         },
     },
     "Deep_Ponder": {
         "tags": {
-            "pose": ["sitting cross-legged", "cupping chin", "leaning forward", "hand on cheek"],
-            "expression": ["pensive", "thoughtful", "serious", "neutral expression", "knitted brows"],
-            "camera": ["face shot", "point of view shot", "window light"],
+            "pose": [
+                "sitting cross-legged with chin in hand",
+                "leaning on railing lost in thought",
+                "hand resting against temple",
+                "standing with arms gently folded",
+            ],
+            "expression": [
+                "thoughtful gaze",
+                "soft focus eyes",
+                "subtle smile of contemplation",
+                "slight frown in concentration",
+            ],
+            "camera": ["face shot", "shoulder-level portrait", "window light profile"],
+            "accent": ["dust motes in sunlight", "pen poised above notebook"],
         },
         "focus": {
             "pose": ["pose_sitting", "pose_standing"],
-            "expression": ["daily"],
+            "expression": ["daily", "neutral"],
         },
         "conflicts": {
-            "pose_categories": ["pose_dynamic"],
+            "pose_categories": ["pose_dynamic", "pose_lying"],
             "mood_labels": ["anger", "erotic"],
+            "tags": ["tears", "wild laughter", "scream"],
         },
     },
     "Passionate_Embrace": {
         "tags": {
-            "pose": ["arched back", "lying on back", "hands behind head", "legs wrapped around", "embracing"],
-            "expression": ["lustful", "ecstasy", "biting lip", "breathless", "half-closed eyes", "passionate"],
-            "camera": ["close-up", "tight crop", "dramatic lighting", "shadows"],
+            "pose": [
+                "arched back against unseen partner",
+                "lying back with arms overhead",
+                "legs entwined",
+                "hands gripping sheets",
+            ],
+            "expression": [
+                "breathless",
+                "eyes half closed",
+                "biting lip",
+                "flushed ecstasy",
+                "soft moan",
+            ],
+            "camera": ["tight crop", "close-up", "dramatic chiaroscuro lighting"],
+            "accent": ["glowing sweat sheen", "rumpled fabric"],
         },
         "focus": {
-            "pose": ["pose_lying", "pose_sitting", "pose_dynamic"],
+            "pose": ["pose_lying", "pose_sitting"],
             "expression": ["erotic", "allure"],
         },
         "conflicts": {
-            "mood_labels": ["sadness", "anger"],
+            "pose_categories": ["pose_dynamic", "pose_standing"],
+            "mood_labels": ["sadness", "anger", "joy"],
+            "tags": ["tears", "smirk", "grin"],
         },
     },
 }


### PR DESCRIPTION
## Summary
- restructure clothing vocabulary into concept packs and rewrite the clothing tag generator to assemble cohesive outfits with optional outerwear additions
- reorganize background vocabularies into scene concept packs and update the background tag node to pick packs by theme and filter while respecting UI probabilities
- refresh emotion theme packs with stricter conflicts plus ensure conflicting mood pools are pruned, and soften appearance jawline descriptors to keep the set feminine

## Testing
- python -m compileall wildcard_tagnodes

------
https://chatgpt.com/codex/tasks/task_e_69007c79aa6883269876240e71dff029